### PR TITLE
Explicitly-defined backends and possible extensions with different defaults per platform

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,12 @@ OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 Unrolled = "9602ed7d-8fef-5bc8-8597-8f21381861e8"
 
+[weakdeps]
+oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
+
+[extensions]
+PlatformDependentoneAPIExt = "oneAPI"
+
 [compat]
 ArgCheck = "2"
 DocStringExtensions = "0.9"
@@ -23,3 +29,4 @@ OhMyThreads = "0.7"
 Polyester = "0.7"
 Unrolled = "0.1"
 julia = "1.10"
+oneAPI = "1"

--- a/docs/src/api/binarysearch.md
+++ b/docs/src/api/binarysearch.md
@@ -5,36 +5,6 @@ Find the indices where some elements `x` should be inserted into a sorted sequen
 - `searchsortedlast!`, `searchsortedlast`: index of last element in `v` <= `x[j]`.
 - **Other names**: `thrust::upper_bound`, `std::lower_bound`.
 
-Function signature:
-```julia
-# GPU
-searchsortedfirst!(ix::AbstractGPUVector, v::AbstractGPUVector, x::AbstractGPUVector;
-                   by=identity, lt=(<), rev::Bool=false,
-                   block_size::Int=256)
-searchsortedfirst(v::AbstractGPUVector, x::AbstractGPUVector;
-                  by=identity, lt=(<), rev::Bool=false,
-                  block_size::Int=256)
-searchsortedlast!(ix::AbstractGPUVector, v::AbstractGPUVector, x::AbstractGPUVector;
-                  by=identity, lt=(<), rev::Bool=false,
-                  block_size::Int=256)
-searchsortedlast(v::AbstractGPUVector, x::AbstractGPUVector;
-                 by=identity, lt=(<), rev::Bool=false,
-                 block_size::Int=256)
-
-# CPU
-searchsortedfirst!(ix::AbstractVector, v::AbstractVector, x::AbstractVector;
-                   by=identity, lt=(<), rev::Bool=false,
-                   max_tasks::Int=Threads.nthreads(), min_elems::Int=1000)
-searchsortedfirst(v::AbstractVector, x::AbstractVector;
-                  by=identity, lt=(<), rev::Bool=false,
-                  max_tasks::Int=Threads.nthreads(), min_elems::Int=1000)
-searchsortedlast!(ix::AbstractVector, v::AbstractVector, x::AbstractVector;
-                  by=identity, lt=(<), rev::Bool=false,
-                  max_tasks::Int=Threads.nthreads(), min_elems::Int=1000)
-searchsortedlast(v::AbstractVector, x::AbstractVector;
-                 by=identity, lt=(<), rev::Bool=false,
-                 max_tasks::Int=Threads.nthreads(), min_elems::Int=1000)
-```
 
 Example:
 ```julia
@@ -50,4 +20,12 @@ x = MtlArray(rand(Float32, 10_000))
 ix = MtlArray{Int}(undef, 10_000)
 
 AK.searchsortedfirst!(ix, v, x)
+```
+
+
+```@docs
+AcceleratedKernels.searchsortedfirst!
+AcceleratedKernels.searchsortedfirst
+AcceleratedKernels.searchsortedlast!
+AcceleratedKernels.searchsortedlast
 ```

--- a/docs/src/api/sort.md
+++ b/docs/src/api/sort.md
@@ -5,15 +5,12 @@ Sorting algorithms with similar interface and default settings as the Julia Base
 - `sortperm!`, `sortperm`
 - **Other names**: `sort`, `sort_team`, `sort_team_by_key`, `stable_sort` or variations in Kokkos, RAJA, Thrust that I know of.
 
-Function signature:
-```julia
-sort!(v::AbstractGPUVector;
-      lt=isless, by=identity, rev::Bool=false, order::Base.Order.Ordering=Base.Order.Forward,
-      block_size::Int=256, temp::Union{Nothing, AbstractGPUVector}=nothing)
-
-sortperm!(ix::AbstractGPUVector, v::AbstractGPUVector;
-          lt=isless, by=identity, rev::Bool=false, order::Base.Order.Ordering=Base.Order.Forward,
-          block_size::Int=256, temp::Union{Nothing, AbstractGPUVector}=nothing)
+Function signatures:
+```@docs
+AcceleratedKernels.sort!
+AcceleratedKernels.sort
+AcceleratedKernels.sortperm!
+AcceleratedKernels.sortperm
 ```
 
 Specific implementations that the interfaces above forward to:
@@ -21,28 +18,16 @@ Specific implementations that the interfaces above forward to:
 - `merge_sort_by_key!`, `merge_sort_by_key` - sort a vector of keys along with a "payload", a vector of corresponding values.
 - `merge_sortperm!`, `merge_sortperm`, `merge_sortperm_lowmem!`, `merge_sortperm_lowmem` - compute a sorting index permutation. 
 
-Function signature:
-```julia
-merge_sort!(v::AbstractGPUVector;
-            lt=(<), by=identity, rev::Bool=false, order::Ordering=Forward,
-            block_size::Int=256, temp::Union{Nothing, AbstractGPUVector}=nothing)
-
-merge_sort_by_key!(keys::AbstractGPUVector, values::AbstractGPUVector;
-                   lt=(<), by=identity, rev::Bool=false, order::Ordering=Forward,
-                   block_size::Int=256,
-                   temp_keys::Union{Nothing, AbstractGPUVector}=nothing,
-                   temp_values::Union{Nothing, AbstractGPUVector}=nothing)
-
-merge_sortperm!(ix::AbstractGPUVector, v::AbstractGPUVector;
-                lt=(<), by=identity, rev::Bool=false, order::Ordering=Forward,
-                inplace::Bool=false, block_size::Int=256,
-                temp_ix::Union{Nothing, AbstractGPUVector}=nothing,
-                temp_v::Union{Nothing, AbstractGPUVector}=nothing)
-
-merge_sortperm_lowmem!(ix::AbstractGPUVector, v::AbstractGPUVector;
-                       lt=(<), by=identity, rev::Bool=false, order::Ordering=Forward,
-                       block_size::Int=256,
-                       temp::Union{Nothing, AbstractGPUVector}=nothing)
+Function signatures:
+```@docs
+AcceleratedKernels.merge_sort!
+AcceleratedKernels.merge_sort
+AcceleratedKernels.merge_sort_by_key!
+AcceleratedKernels.merge_sort_by_key
+AcceleratedKernels.merge_sortperm!
+AcceleratedKernels.merge_sortperm
+AcceleratedKernels.merge_sortperm_lowmem!
+AcceleratedKernels.merge_sortperm_lowmem
 ```
 
 Example:

--- a/ext/PlatformDependentoneAPIExt.jl
+++ b/ext/PlatformDependentoneAPIExt.jl
@@ -1,0 +1,64 @@
+module PlatformDependentoneAPIExt
+
+
+using oneAPI
+import AcceleratedKernels as AK
+
+
+# On oneAPI, use `cooperative=false` by default as on some Intel GPUs concurrent global writes hang
+# the device.
+function AK.any(
+    pred, v::AbstractArray, backend::oneBackend;
+
+    # CPU settings
+    max_tasks=Threads.nthreads(),
+    min_elems=1,
+
+    # GPU settings
+    block_size::Int=256,
+    cooperative::Bool=false,
+
+    # GPU settings passed to mapreduce, only used if cooperative=false
+    temp::Union{Nothing, AbstractArray}=nothing,
+    switch_below::Int=0,
+)
+    AK._any_impl(
+        pred, v, backend;
+        max_tasks=max_tasks,
+        min_elems=min_elems,
+        block_size=block_size,
+        cooperative=cooperative,
+        temp=temp,
+        switch_below=switch_below,
+    )
+end
+
+
+function AK.all(
+    pred, v::AbstractArray, backend::oneBackend;
+
+    # CPU settings
+    max_tasks=Threads.nthreads(),
+    min_elems=1,
+
+    # GPU settings
+    block_size::Int=256,
+    cooperative::Bool=false,
+
+    # GPU settings passed to mapreduce, only used if cooperative=false
+    temp::Union{Nothing, AbstractArray}=nothing,
+    switch_below::Int=0,
+)
+    AK._all_impl(
+        pred, v, backend;
+        max_tasks=max_tasks,
+        min_elems=min_elems,
+        block_size=block_size,
+        cooperative=cooperative,
+        temp=temp,
+        switch_below=switch_below,
+    )
+end
+
+
+end   # module PlatformDependentoneAPI

--- a/ext/PlatformDependentoneAPIExt.jl
+++ b/ext/PlatformDependentoneAPIExt.jl
@@ -8,7 +8,7 @@ import AcceleratedKernels as AK
 # On oneAPI, use `cooperative=false` by default as on some Intel GPUs concurrent global writes hang
 # the device.
 function AK.any(
-    pred, v::AbstractArray, backend::oneBackend;
+    pred, v::AbstractArray, backend::oneAPIBackend;
 
     # CPU settings
     max_tasks=Threads.nthreads(),
@@ -35,7 +35,7 @@ end
 
 
 function AK.all(
-    pred, v::AbstractArray, backend::oneBackend;
+    pred, v::AbstractArray, backend::oneAPIBackend;
 
     # CPU settings
     max_tasks=Threads.nthreads(),

--- a/prototype/reduce_nd_test.jl
+++ b/prototype/reduce_nd_test.jl
@@ -23,10 +23,13 @@ end
 
 # Make array with highly unequal per-axis sizes
 s = MtlArray(rand(Int32(1):Int32(100), 10, 1_000_000))
+AK.reduce(+, s, init=zero(eltype(s)))
+ret
 
 # Correctness
 @assert sum_base(s, dims=1) == sum_ak(s, dims=1)
 @assert sum_base(s, dims=2) == sum_ak(s, dims=2)
+
 
 # Benchmarks
 println("\nReduction over small axis - AK vs Base")

--- a/prototype/truth_test.jl
+++ b/prototype/truth_test.jl
@@ -17,6 +17,7 @@ Random.seed!(0)
 
 v = MtlArray(1:100)
 
+
 @assert AK.any(x->x<0, v, cooperative=false) === false
 @assert AK.any(x->x>99, v, cooperative=false) === true
 println("simple any tests passed")

--- a/src/AcceleratedKernels.jl
+++ b/src/AcceleratedKernels.jl
@@ -32,7 +32,7 @@ include("foreachindex.jl")
 include("map.jl")
 include("sort/sort.jl")
 include("reduce/reduce.jl")
-include("accumulate.jl")
+include("accumulate/accumulate.jl")
 include("searchsorted.jl")
 include("truth.jl")
 

--- a/src/accumulate/accumulate.jl
+++ b/src/accumulate/accumulate.jl
@@ -1,0 +1,128 @@
+include("accumulate_1d.jl")
+
+
+"""
+    accumulate!(
+        op, v::AbstractArray, backend::Backend=get_backend(v);
+        init,
+        inclusive::Bool=true,
+
+        block_size::Int=256,
+        temp::Union{Nothing, AbstractArray}=nothing,
+        temp_flags::Union{Nothing, AbstractArray}=nothing,
+    )
+
+Compute accumulated running totals along a sequence by applying a binary operator to all elements
+up to the current one; often used in GPU programming as a first step in finding / extracting
+subsets of data.
+
+**Other names**: prefix sum, `thrust::scan`, cumulative sum; inclusive (or exclusive) if the first
+element is included in the accumulation (or not).
+
+The `block_size` should be a power of 2 and greater than 0. The temporaries `temp` and `temp_flags`
+should both have at least
+`(length(v) + 2 * block_size - 1) ÷ (2 * block_size)` elements; `eltype(v) === eltype(temp)`; the
+elements in `temp_flags` can be any integers, but `Int8` is used by default to reduce memory usage. 
+
+# Platform-Specific Notes
+Currently, Apple Metal GPUs do not have strong enough memory consistency guarantees to support the
+industry-standard "decoupled lookback" algorithm for prefix sums - which means it currently may,
+for very large arrays, produce incorrect results ~0.38% of the time. We are currently working on an
+alternative algorithm without lookback ([issue](https://github.com/JuliaGPU/AcceleratedKernels.jl/issues/10)).
+
+The CPU implementation currently defers to the single-threaded Base.accumulate!; we are waiting on a
+multithreaded implementation in OhMyThreads.jl ([issue](https://github.com/JuliaFolds2/OhMyThreads.jl/issues/129)).
+
+# Examples
+Example computing an inclusive prefix sum (the typical GPU "scan"):
+```julia
+import AcceleratedKernels as AK
+using oneAPI
+
+v = oneAPI.ones(Int32, 100_000)
+AK.accumulate!(+, v, init=0)
+```
+"""
+function accumulate!(
+    op, v::AbstractArray, backend::Backend=get_backend(v);
+    init,
+    inclusive::Bool=true,
+
+    block_size::Int=256,
+    temp::Union{Nothing, AbstractArray}=nothing,
+    temp_flags::Union{Nothing, AbstractArray}=nothing,
+)
+    _accumulate_impl!(
+        op, v, backend,
+        init=init, inclusive=inclusive,
+        block_size=block_size, temp=temp, temp_flags=temp_flags,
+    )
+end
+
+
+function _accumulate_impl!(
+    op, v::AbstractArray, backend::Backend;
+    init,
+    inclusive::Bool=true,
+
+    block_size::Int=256,
+    temp::Union{Nothing, AbstractArray}=nothing,
+    temp_flags::Union{Nothing, AbstractArray}=nothing,
+)
+    if backend isa GPU
+        accumulate_1d!(
+            op, v, backend,
+            init=init, inclusive=inclusive,
+            block_size=block_size, temp=temp, temp_flags=temp_flags,
+        )
+        return v
+    else
+        # Simple single-threaded CPU implementation - FIXME: implement taccumulate in OhMyThreads.jl
+        if length(v) == 0
+            return v
+        end
+        if inclusive
+            running = v[begin]
+            for i in firstindex(v) + 1:lastindex(v)
+                running = op(running, v[i])
+                v[i] = running
+            end
+        else
+            running = init
+            for i in eachindex(v)
+                v[i], running = running, op(running, v[i])
+            end
+        end
+        return v
+    end
+end
+
+
+"""
+    accumulate(
+        op, v::AbstractArray, backend::Backend=get_backend(v);
+        init,
+        inclusive::Bool=true,
+
+        block_size::Int=256,
+        temp::Union{Nothing, AbstractArray}=nothing,
+        temp_flags::Union{Nothing, AbstractArray}=nothing,
+    )
+
+Out-of-place version of [`accumulate!`](@ref).
+"""
+function accumulate(
+    op, v::AbstractArray, backend::Backend=get_backend(v);
+    init,
+    inclusive::Bool=true,
+
+    block_size::Int=256,
+    temp::Union{Nothing, AbstractArray}=nothing,
+    temp_flags::Union{Nothing, AbstractArray}=nothing,
+)
+    vcopy = copy(v)
+    accumulate!(op, vcopy, backend; init=init, inclusive=inclusive,
+                block_size=block_size, temp=temp, temp_flags=temp_flags)
+    vcopy
+end
+

--- a/src/foreachindex.jl
+++ b/src/foreachindex.jl
@@ -149,20 +149,18 @@ function foreachindex(
     # GPU settings
     block_size=256,
 )
-    if backend isa CPU
+    if backend isa GPU
+        _forindices_gpu(
+            f, eachindex(itr), backend;
+            block_size=block_size,
+        )
+    else
         _forindices_cpu(
             f, eachindex(itr), backend;
             scheduler=scheduler,
             max_tasks=max_tasks,
             min_elems=min_elems,
         )
-    elseif backend isa GPU
-        _forindices_gpu(
-            f, eachindex(itr), backend;
-            block_size=block_size,
-        )
-    else
-        throw(ArgumentError("Backend must be `CPU` or `<:GPU`. Received $backend"))
     end
 end
 
@@ -262,19 +260,17 @@ function foraxes(
         )
     end
 
-    if backend isa CPU
+    if backend isa GPU
+        _forindices_gpu(
+            f, axes(itr, dims), backend;
+            block_size=block_size,
+        )
+    else
         _forindices_cpu(
             f, axes(itr, dims), backend;
             scheduler=scheduler,
             max_tasks=max_tasks,
             min_elems=min_elems,
         )
-    elseif backend isa GPU
-        _forindices_gpu(
-            f, axes(itr, dims), backend;
-            block_size=block_size,
-        )
-    else
-        throw(ArgumentError("Backend must be `CPU` or `<:GPU`. Received $backend"))
     end
 end

--- a/src/map.jl
+++ b/src/map.jl
@@ -1,6 +1,6 @@
 """
     map!(
-        f, dst::AbstractArray, src::AbstractArray;
+        f, dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
 
         # CPU settings
         scheduler=:threads,
@@ -8,7 +8,7 @@
         min_elems=1,
 
         # GPU settings
-        block_size=256,    
+        block_size=256,
     )
 
 Apply the function `f` to each element of `src` in parallel and store the result in `dst`. The
@@ -28,7 +28,7 @@ end
 ```
 """
 function map!(
-    f, dst::AbstractArray, src::AbstractArray;
+    f, dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
 
     # CPU settings
     scheduler=:threads,
@@ -36,11 +36,11 @@ function map!(
     min_elems=1,
 
     # GPU settings
-    block_size=256,    
+    block_size=256,
 )
     @argcheck length(dst) == length(src)
     foreachindex(
-        src,
+        src, backend,
         scheduler=scheduler,
         max_tasks=max_tasks,
         min_elems=min_elems,
@@ -54,7 +54,7 @@ end
 
 """
     map(
-        f, src::AbstractArray;
+        f, src::AbstractArray, backend::Backend=get_backend(src);
 
         # CPU settings
         scheduler=:threads,
@@ -70,7 +70,7 @@ changes the `eltype`, allocate `dst` separately and call [`map!`](@ref)). The CP
 settings are the same as for [`foreachindex`](@ref).
 """
 function map(
-    f, src::AbstractArray;
+    f, src::AbstractArray, backend::Backend=get_backend(src);
 
     # CPU settings
     scheduler=:threads,
@@ -82,7 +82,7 @@ function map(
 )
     dst = similar(src)
     map!(
-        f, dst, src,
+        f, dst, src, backend,
         scheduler=scheduler,
         max_tasks=max_tasks,
         min_elems=min_elems,

--- a/src/reduce/mapreduce_1d.jl
+++ b/src/reduce/mapreduce_1d.jl
@@ -101,11 +101,11 @@ end
 
 
 function mapreduce_1d(
-    f, op, src::AbstractGPUArray;
+    f, op, src::AbstractArray, backend::GPU;
     init,
 
     block_size::Int=256,
-    temp::Union{Nothing, AbstractGPUArray}=nothing,
+    temp::Union{Nothing, AbstractArray}=nothing,
     switch_below::Int=0,
 )
     @argcheck 1 <= block_size <= 1024
@@ -140,7 +140,6 @@ function mapreduce_1d(
     src_view = @view src[1:end]
     dst_view = @view dst[1:blocks]
 
-    backend = get_backend(dst)
     kernel! = _mapreduce_block!(backend, block_size)
     kernel!(src_view, dst_view, f, op, init, ndrange=(block_size * blocks,))
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -177,11 +177,11 @@ end
 
 
 function mapreduce_nd(
-    f, op, src::AbstractGPUArray;
+    f, op, src::AbstractArray, backend::GPU;
     init,
     dims::Int,
     block_size::Int=256,
-    temp::Union{Nothing, AbstractGPUArray}=nothing,
+    temp::Union{Nothing, AbstractArray}=nothing,
 )
     @argcheck 1 <= block_size <= 1024
 
@@ -286,7 +286,6 @@ function mapreduce_nd(
     #   - If the other dimensions have more elements (e.g. reduce(+, rand(3, 1000), dims=1)), we
     #     use a single thread per dst element - thus, a thread reduces the dims axis sequentially,
     #     while the other dimensions are processed in parallel, independently
-    backend = get_backend(dst)
     if dst_size >= src_sizes[dims]
         blocks = (dst_size + block_size - 1) ÷ block_size
         kernel! = _mapreduce_nd_by_thread!(backend, block_size)

--- a/src/reduce/reduce_1d.jl
+++ b/src/reduce/reduce_1d.jl
@@ -102,11 +102,11 @@ end
 
 
 function reduce_1d(
-    op, src::AbstractGPUArray;
+    op, src::AbstractArray, backend::GPU;
     init,
 
     block_size::Int=256,
-    temp::Union{Nothing, AbstractGPUArray}=nothing,
+    temp::Union{Nothing, AbstractArray}=nothing,
     switch_below::Int=0,
 )
     @argcheck 1 <= block_size <= 1024
@@ -126,7 +126,6 @@ function reduce_1d(
     blocks = (len + num_per_block - 1) ÷ num_per_block
 
     if !isnothing(temp)
-        @argcheck get_backend(temp) === get_backend(src)
         @argcheck length(temp) >= blocks * 2
         dst = temp
     else
@@ -137,7 +136,6 @@ function reduce_1d(
     src_view = @view src[1:end]
     dst_view = @view dst[1:blocks]
 
-    backend = get_backend(dst)
     kernel! = _reduce_block!(backend, block_size)
     kernel!(src_view, dst_view, op, init, ndrange=(block_size * blocks,))
 

--- a/src/reduce/reduce_nd.jl
+++ b/src/reduce/reduce_nd.jl
@@ -199,11 +199,11 @@ end
 
 
 function reduce_nd(
-    op, src::AbstractGPUArray;
+    op, src::AbstractArray, backend::GPU;
     init,
     dims::Int,
     block_size::Int=256,
-    temp::Union{Nothing, AbstractGPUArray}=nothing,
+    temp::Union{Nothing, AbstractArray}=nothing,
 )
     @argcheck 1 <= block_size <= 1024
 
@@ -309,7 +309,6 @@ function reduce_nd(
     #   - If the other dimensions have more elements (e.g. reduce(+, rand(3, 1000), dims=1)), we
     #     use a single thread per dst element - thus, a thread reduces the dims axis sequentially,
     #     while the other dimensions are processed in parallel, independently
-    backend = get_backend(dst)
     if dst_size >= src_sizes[dims]
         blocks = (dst_size + block_size - 1) ÷ block_size
         kernel! = _reduce_nd_by_thread!(backend, block_size)

--- a/src/searchsorted.jl
+++ b/src/searchsorted.jl
@@ -34,10 +34,32 @@ function _searchsortedlast(v, x, lo::T, hi::T, comp) where T<:Integer
 end
 
 
+"""
+    searchsortedfirst!(
+        ix::AbstractVector,
+        v::AbstractVector,
+        x::AbstractVector,
+        backend::Backend=get_backend(x);
+
+        by=identity, lt=isless, rev::Bool=false,
+
+        # CPU settings
+        scheduler=:threads,
+        max_tasks::Int=Threads.nthreads(),
+        min_elems::Int=1000,
+
+        # GPU settings
+        block_size::Int=256,
+    )
+
+Equivalent to applying `searchsortedfirst!` element-wise to each element of `x`. The CPU and GPU
+settings are the same as for [`foreachindex`](@ref).
+"""
 function searchsortedfirst!(
     ix::AbstractVector,
     v::AbstractVector,
-    x::AbstractVector;
+    x::AbstractVector,
+    backend::Backend=get_backend(x);
 
     by=identity, lt=isless, rev::Bool=false,
 
@@ -57,7 +79,7 @@ function searchsortedfirst!(
     comp = (x, y) -> Base.Order.lt(ord, x, y)
 
     foreachindex(
-        x,
+        x, backend,
         scheduler=scheduler, max_tasks=max_tasks, min_elems=min_elems,
         block_size=block_size,
     ) do i
@@ -66,9 +88,30 @@ function searchsortedfirst!(
 end
 
 
+"""
+    searchsortedfirst(
+        v::AbstractVector,
+        x::AbstractVector,
+        backend::Backend=get_backend(x);
+
+        by=identity, lt=isless, rev::Bool=false,
+
+        # CPU settings
+        scheduler=:threads,
+        max_tasks::Int=Threads.nthreads(),
+        min_elems::Int=1000,
+
+        # GPU settings
+        block_size::Int=256,
+    )
+
+Equivalent to applying `searchsortedfirst` element-wise to each element of `x`. The CPU and GPU
+settings are the same as for [`foreachindex`](@ref).
+"""
 function searchsortedfirst(
     v::AbstractVector,
-    x::AbstractVector;
+    x::AbstractVector,
+    backend::Backend=get_backend(x);
 
     by=identity, lt=isless, rev::Bool=false,
 
@@ -82,7 +125,7 @@ function searchsortedfirst(
 )
     ix = similar(x, Int)
     searchsortedfirst!(
-        ix, v, x;
+        ix, v, x, backend;
         by=by, lt=lt, rev=rev,
         scheduler=scheduler, max_tasks=max_tasks, min_elems=min_elems,
         block_size=block_size,
@@ -91,10 +134,32 @@ function searchsortedfirst(
 end
 
 
+"""
+    searchsortedlast!(
+        ix::AbstractVector,
+        v::AbstractVector,
+        x::AbstractVector,
+        backend::Backend=get_backend(x);
+
+        by=identity, lt=isless, rev::Bool=false,
+
+        # CPU settings
+        scheduler=:threads,
+        max_tasks::Int=Threads.nthreads(),
+        min_elems::Int=1000,
+
+        # GPU settings
+        block_size::Int=256,
+    )
+
+Equivalent to applying `searchsortedlast!` element-wise to each element of `x`. The CPU and GPU
+settings are the same as for [`foreachindex`](@ref).
+"""
 function searchsortedlast!(
     ix::AbstractVector,
     v::AbstractVector,
-    x::AbstractVector;
+    x::AbstractVector,
+    backend::Backend=get_backend(x);
 
     by=identity, lt=isless, rev::Bool=false,
 
@@ -106,7 +171,6 @@ function searchsortedlast!(
     # GPU settings
     block_size::Int=256,
 )
-
     # Simple sanity checks
     @argcheck block_size > 0
     @argcheck length(ix) == length(x)
@@ -116,7 +180,7 @@ function searchsortedlast!(
     comp = (x, y) -> Base.Order.lt(ord, x, y)
 
     foreachindex(
-        x,
+        x, backend,
         scheduler=scheduler, max_tasks=max_tasks, min_elems=min_elems,
         block_size=block_size,
     ) do i
@@ -125,9 +189,30 @@ function searchsortedlast!(
 end
 
 
+"""
+    searchsortedlast(
+        v::AbstractVector,
+        x::AbstractVector,
+        backend::Backend=get_backend(x);
+
+        by=identity, lt=isless, rev::Bool=false,
+
+        # CPU settings
+        scheduler=:threads,
+        max_tasks::Int=Threads.nthreads(),
+        min_elems::Int=1000,
+
+        # GPU settings
+        block_size::Int=256,
+    )
+
+Equivalent to applying `searchsortedlast` element-wise to each element of `x`. The CPU and GPU
+settings are the same as for [`foreachindex`](@ref).
+"""
 function searchsortedlast(
     v::AbstractVector,
-    x::AbstractVector;
+    x::AbstractVector,
+    backend::Backend=get_backend(x);
 
     by=identity, lt=isless, rev::Bool=false,
 
@@ -141,7 +226,7 @@ function searchsortedlast(
 )
     ix = similar(x, Int)
     searchsortedlast!(
-        ix, v, x;
+        ix, v, x, backend;
         by=by, lt=lt, rev=rev,
         scheduler=scheduler, max_tasks=max_tasks, min_elems=min_elems,
         block_size=block_size,

--- a/src/sort/merge_sort.jl
+++ b/src/sort/merge_sort.jl
@@ -122,8 +122,21 @@ end
 end
 
 
+"""
+    merge_sort!(
+        v::AbstractArray, backend::Backend=get_backend(v);
+
+        lt=isless,
+        by=identity,
+        rev::Bool=false,
+        order::Base.Order.Ordering=Base.Order.Forward,
+
+        block_size::Int=256,
+        temp::Union{Nothing, AbstractArray}=nothing,
+    )
+"""
 function merge_sort!(
-    v::AbstractGPUVector;
+    v::AbstractArray, backend::Backend=get_backend(v);
 
     lt=isless,
     by=identity,
@@ -131,7 +144,7 @@ function merge_sort!(
     order::Base.Order.Ordering=Base.Order.Forward,
 
     block_size::Int=256,
-    temp::Union{Nothing, AbstractGPUVector}=nothing,
+    temp::Union{Nothing, AbstractArray}=nothing,
 )
     # Simple sanity checks
     @argcheck block_size > 0
@@ -145,7 +158,6 @@ function merge_sort!(
     comp = (x, y) -> Base.Order.lt(ord, x, y)
 
     # Block level
-    backend = get_backend(v)
     blocks = (length(v) + block_size * 2 - 1) ÷ (block_size * 2)
     _merge_sort_block!(backend, block_size)(v, comp, ndrange=(block_size * blocks,))
 
@@ -180,8 +192,21 @@ function merge_sort!(
 end
 
 
+"""
+    merge_sort(
+        v::AbstractVector, backend::Backend=get_backend(v);
+
+        lt=isless,
+        by=identity,
+        rev::Bool=false,
+        order::Base.Order.Ordering=Base.Order.Forward,
+
+        block_size::Int=256,
+        temp::Union{Nothing, AbstractGPUVector}=nothing,
+    )
+"""
 function merge_sort(
-    v::AbstractGPUVector;
+    v::AbstractVector, backend::Backend=get_backend(v);
 
     lt=isless,
     by=identity,
@@ -193,7 +218,7 @@ function merge_sort(
 )
     v_copy = copy(v)
     merge_sort!(
-        v_copy,
+        v_copy, backend,
         lt=lt, by=by, rev=rev, order=order,
         block_size=block_size, temp=temp,
     )

--- a/src/sort/merge_sort_by_key.jl
+++ b/src/sort/merge_sort_by_key.jl
@@ -151,9 +151,26 @@ end
 end
 
 
+"""
+    merge_sort_by_key!(
+        keys::AbstractArray,
+        values::AbstractArray,
+        backend::Backend=get_backend(keys);
+
+        lt=isless,
+        by=identity,
+        rev::Bool=false,
+        order::Base.Order.Ordering=Base.Order.Forward,
+
+        block_size::Int=256,
+        temp_keys::Union{Nothing, AbstractArray}=nothing,
+        temp_values::Union{Nothing, AbstractArray}=nothing,
+    )
+"""
 function merge_sort_by_key!(
-    keys::AbstractGPUVector,
-    values::AbstractGPUVector;
+    keys::AbstractArray,
+    values::AbstractArray,
+    backend::Backend=get_backend(keys);
 
     lt=isless,
     by=identity,
@@ -161,8 +178,8 @@ function merge_sort_by_key!(
     order::Base.Order.Ordering=Base.Order.Forward,
 
     block_size::Int=256,
-    temp_keys::Union{Nothing, AbstractGPUVector}=nothing,
-    temp_values::Union{Nothing, AbstractGPUVector}=nothing,
+    temp_keys::Union{Nothing, AbstractArray}=nothing,
+    temp_values::Union{Nothing, AbstractArray}=nothing,
 )
     # Simple sanity checks
     @argcheck block_size > 0
@@ -181,7 +198,6 @@ function merge_sort_by_key!(
     comp = (x, y) -> Base.Order.lt(ord, x, y)
 
     # Block level
-    backend = get_backend(keys)
     blocks = (length(keys) + block_size * 2 - 1) ÷ (block_size * 2)
     _merge_sort_by_key_block!(backend, block_size)(keys, values, comp, ndrange=(block_size * blocks,))
 
@@ -221,9 +237,26 @@ function merge_sort_by_key!(
 end
 
 
+"""
+    merge_sort_by_key(
+        keys::AbstractGPUVector,
+        values::AbstractGPUVector,
+        backend::Backend=get_backend(keys);
+
+        lt=isless,
+        by=identity,
+        rev::Bool=false,
+        order::Base.Order.Ordering=Base.Order.Forward,
+
+        block_size::Int=256,
+        temp_keys::Union{Nothing, AbstractGPUVector}=nothing,
+        temp_values::Union{Nothing, AbstractGPUVector}=nothing,
+    )
+"""
 function merge_sort_by_key(
     keys::AbstractGPUVector,
-    values::AbstractGPUVector;
+    values::AbstractGPUVector,
+    backend::Backend=get_backend(keys);
 
     lt=isless,
     by=identity,
@@ -238,9 +271,8 @@ function merge_sort_by_key(
     values_copy = copy(values)
 
     merge_sort_by_key!(
-        keys_copy, values_copy,
+        keys_copy, values_copy, backend,
         lt=lt, by=by, rev=rev, order=order,
         block_size=block_size, temp_keys=temp_keys, temp_values=temp_values,
     )
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1167,36 +1167,28 @@ end
     # Simple correctness tests
     v = array_from_host(1:100)
 
-    # mapreduce implementation
-    @test AK.any(x->x<0, v, cooperative=false) === false
-    @test AK.any(x->x>99, v, cooperative=false) === true
+    @test AK.any(x->x<0, v) === false
+    @test AK.any(x->x>99, v) === true
 
-    @test AK.all(x->x>0, v, cooperative=false) === true
-    @test AK.all(x->x<100, v, cooperative=false) === false
-
-    # shortcircuiting GPU implementation
-    @test AK.any(x->x<0, v, cooperative=true) === false
-    @test AK.any(x->x>99, v, cooperative=true) === true
-
-    @test AK.all(x->x>0, v, cooperative=true) === true
-    @test AK.all(x->x<100, v, cooperative=true) === false
+    @test AK.all(x->x>0, v) === true
+    @test AK.all(x->x<100, v) === false
 
     for _ in 1:100
         num_elems = rand(1:100_000)
         v = array_from_host(rand(Float32, num_elems))
-        @test AK.any(x->x<0, v, cooperative=false) === false
-        @test AK.any(x->x<1, v, cooperative=false) === true
-        @test AK.all(x->x<1, v, cooperative=false) === true
-        @test AK.all(x->x<0, v, cooperative=false) === false
+        @test AK.any(x->x<0, v) === false
+        @test AK.any(x->x<1, v) === true
+        @test AK.all(x->x<1, v) === true
+        @test AK.all(x->x<0, v) === false
     end
 
     for _ in 1:100
         num_elems = rand(1:100_000)
         v = array_from_host(rand(Float32, num_elems))
-        @test AK.any(x->x<0, v, cooperative=true) === false
-        @test AK.any(x->x<1, v, cooperative=true) === true
-        @test AK.all(x->x<1, v, cooperative=true) === true
-        @test AK.all(x->x<0, v, cooperative=true) === false
+        @test AK.any(x->x<0, v) === false
+        @test AK.any(x->x<1, v) === true
+        @test AK.all(x->x<1, v) === true
+        @test AK.all(x->x<0, v) === false
     end
 
     # Testing different settings


### PR DESCRIPTION
- Refactored functions to accept explicit backend; this also allows unmaterialised Julia iterators (e.g. ranges and OneTo) to be used transparently in GPU kernels without explicit conversion to the backend
- It allows extensions to redefine default values for some platforms
  - Thus, added `cooperative=false` to `any` and `all` on oneAPI as it seems to hang with cooperative global writes.
- Function signatures were expanded as perfect supersets of previous ones
  - Thus, it is backwards-compatible.
- Moved docs' signatures fully into Documenter.