### PR TITLE
Added new `ScanPrefix` accumulate algorithm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,11 @@ Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 Unrolled = "9602ed7d-8fef-5bc8-8597-8f21381861e8"
 
 [weakdeps]
+Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 
 [extensions]
+PlatformDependentMetalExt = "Metal"
 PlatformDependentoneAPIExt = "oneAPI"
 
 [compat]
@@ -25,6 +27,7 @@ DocStringExtensions = "0.9"
 GPUArraysCore = "0.1, 0.2"
 KernelAbstractions = "0.9"
 Markdown = "1"
+Metal = "1.4.2"
 OhMyThreads = "0.7"
 Polyester = "0.7"
 Unrolled = "0.1"

--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ Julia v1.11
 
 [Metal](https://github.com/JuliaGPU/Metal.jl)
 
-[Known Issue with `accumulate` Only](https://github.com/JuliaGPU/AcceleratedKernels.jl/issues/10) 
-
 </td>
 <td>
 

--- a/ext/PlatformDependentMetalExt.jl
+++ b/ext/PlatformDependentMetalExt.jl
@@ -1,0 +1,32 @@
+module PlatformDependentMetalExt
+
+
+using Metal
+import AcceleratedKernels as AK
+
+
+# On Metal use the ScanPrefixes accumulation algorithm by default as the DecoupledLookback algorithm
+# cannot be supported due to Metal's weaker memory consistency guarantees.
+function AK.accumulate!(
+    op, v::AbstractArray, backend::MetalBackend;
+    init,
+    inclusive::Bool=true,
+
+    # Algorithm choice
+    alg::AK.AccumulateAlgorithm=AK.ScanPrefixes(),
+
+    # GPU settings
+    block_size::Int=1024,
+    temp::Union{Nothing, AbstractArray}=nothing,
+    temp_flags::Union{Nothing, AbstractArray}=nothing,
+)
+    AK._accumulate_impl!(
+        op, v, backend,
+        init=init, inclusive=inclusive,
+        alg=alg,
+        block_size=block_size, temp=temp, temp_flags=temp_flags,
+    )
+end
+
+
+end   # module PlatformDependentMetalExt

--- a/prototype/accumulate_benchmark.jl
+++ b/prototype/accumulate_benchmark.jl
@@ -7,7 +7,7 @@ Random.seed!(0)
 
 
 function akacc(v)
-    va = AK.accumulate(+, v, init=zero(eltype(v)), block_size=512)
+    va = AK.accumulate(+, v, init=zero(eltype(v)), block_size=1024)
     Metal.synchronize()
     va
 end

--- a/prototype/accumulate_test_metal.jl
+++ b/prototype/accumulate_test_metal.jl
@@ -1,0 +1,22 @@
+
+using Random
+using BenchmarkTools
+using Profile
+using PProf
+
+using KernelAbstractions
+using Metal
+
+import AcceleratedKernels as AK
+
+
+Random.seed!(0)
+
+
+v = Metal.ones(Int32, 100)
+
+v2 = AK.accumulate!(+, copy(v), init=zero(eltype(v)), block_size=1024)
+
+@assert Array(v2) == cumsum(Array(v))
+
+v2

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -23,8 +23,6 @@
     iblock = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    tid = ithread + iblock * N
-
     # Each thread handles one output element
     tid = ithread + iblock * N
     if tid < output_size

--- a/src/reduce/reduce_nd.jl
+++ b/src/reduce/reduce_nd.jl
@@ -23,8 +23,6 @@
     iblock = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    tid = ithread + iblock * N
-
     # Each thread handles one output element
     tid = ithread + iblock * N
     if tid < output_size

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,34 +11,34 @@ import Pkg
 if "--CUDA" in ARGS
     Pkg.add("CUDA")
     using CUDA
-    display(CUDA.versioninfo())
+    CUDA.versioninfo()
     const backend = CUDABackend()
 elseif "--oneAPI" in ARGS
     Pkg.add("oneAPI")
     using oneAPI
-    display(oneAPI.versioninfo())
+    oneAPI.versioninfo()
     const backend = oneAPIBackend()
 elseif "--AMDGPU" in ARGS
     Pkg.add("AMDGPU")
     using AMDGPU
-    display(AMDGPU.versioninfo())
+    AMDGPU.versioninfo()
     const backend = ROCBackend()
 elseif "--Metal" in ARGS
     Pkg.add("Metal")
     using Metal
-    display(Metal.versioninfo())
+    Metal.versioninfo()
     const backend = MetalBackend()
 elseif "--OpenCL" in ARGS
     Pkg.add(name="OpenCL", rev="master")
     Pkg.add("pocl_jll")
     using pocl_jll
     using OpenCL
-    display(OpenCL.versioninfo())
+    OpenCL.versioninfo()
     const backend = OpenCLBackend()
 elseif !@isdefined(backend)
     # Otherwise do CPU tests
     using InteractiveUtils
-    display(InteractiveUtils.versioninfo())
+    InteractiveUtils.versioninfo()
     const backend = CPU()
 end
 
@@ -1056,6 +1056,15 @@ end
         x = array_from_host(rand(1:1000, num_elems), Int32)
         y = copy(x)
         AK.accumulate!(+, y; init=0)
+        @test all(Array(y) .== accumulate(+, Array(x)))
+    end
+
+    # Stress-testing small block sizes -> many blocks
+    for _ in 1:100
+        num_elems = rand(1:100_000)
+        x = array_from_host(rand(1:1000, num_elems), Int32)
+        y = copy(x)
+        AK.accumulate!(+, y; init=0, block_size=8)
         @test all(Array(y) .== accumulate(+, Array(x)))
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1064,7 +1064,7 @@ end
         num_elems = rand(1:100_000)
         x = array_from_host(rand(1:1000, num_elems), Int32)
         y = copy(x)
-        AK.accumulate!(+, y; init=0, block_size=8)
+        AK.accumulate!(+, y; init=0, block_size=16)
         @test all(Array(y) .== accumulate(+, Array(x)))
     end
 


### PR DESCRIPTION
Added second accumulate algorithm using coupled lookback of pre-scanned prefixes (=> one extra kernel launch), with that `ScanPrefixes` algorithm becoming the default on Metal.

This fixes [the decoupled-lookback issue on Metal](https://github.com/JuliaGPU/AcceleratedKernels.jl/issues/10).