### PR TITLE
mark values used in localmem initialization as uniform

### DIFF
--- a/src/accumulate/accumulate_1d.jl
+++ b/src/accumulate/accumulate_1d.jl
@@ -19,7 +19,7 @@ end
     # NOTE: shmem_size MUST be greater than 2 * block_size
     # NOTE: block_size MUST be a power of 2
     len = length(v)
-    block_size = @groupsize()[1]
+    @uniform block_size = @groupsize()[1]
     temp = @localmem eltype(v) (0x2 * block_size + conflict_free_offset(0x2 * block_size),)
 
     # NOTE: for many index calculations in this library, computation using zero-indexing leads to

--- a/src/accumulate/accumulate_nd.jl
+++ b/src/accumulate/accumulate_nd.jl
@@ -73,7 +73,7 @@ end
     length_dims = vsizes[dims]
     length_outer = length(v) ÷ length_dims
 
-    block_size = @groupsize()[1]
+    @uniform block_size = @groupsize()[1]
 
     temp = @localmem eltype(v) (0x2 * block_size + conflict_free_offset(0x2 * block_size),)
     running_prefix = @localmem eltype(v) (1,)

--- a/src/reduce/mapreduce_1d.jl
+++ b/src/reduce/mapreduce_1d.jl
@@ -1,6 +1,6 @@
 @kernel inbounds=true cpu=false function _mapreduce_block!(@Const(src), dst, f, op, init)
 
-    N = @groupsize()[1]
+    @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
     len = length(src)

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -78,7 +78,7 @@ end
 
     ndims = length(src_sizes)
 
-    N = @groupsize()[1]
+    @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
     # NOTE: for many index calculations in this library, computation using zero-indexing leads to

--- a/src/reduce/reduce_1d.jl
+++ b/src/reduce/reduce_1d.jl
@@ -1,6 +1,6 @@
 @kernel inbounds=true cpu=false function _reduce_block!(@Const(src), dst, op, init)
 
-    N = @groupsize()[1]
+    @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
     len = length(src)

--- a/src/reduce/reduce_nd.jl
+++ b/src/reduce/reduce_nd.jl
@@ -78,7 +78,7 @@ end
 
     ndims = length(src_sizes)
 
-    N = @groupsize()[1]
+    @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
     # NOTE: for many index calculations in this library, computation using zero-indexing leads to

--- a/src/sort/merge_sort.jl
+++ b/src/sort/merge_sort.jl
@@ -1,6 +1,6 @@
 @kernel inbounds=true function _merge_sort_block!(vec, comp)
 
-    N = @groupsize()[1]
+    @uniform N = @groupsize()[1]
     s_buf = @localmem eltype(vec) (N * 0x2,)
 
     T = eltype(vec)

--- a/src/sort/merge_sort_by_key.jl
+++ b/src/sort/merge_sort_by_key.jl
@@ -1,6 +1,6 @@
 @kernel inbounds=true function _merge_sort_by_key_block!(keys, values, comp)
 
-    N = @groupsize()[1]
+    @uniform N = @groupsize()[1]
     s_keys = @localmem eltype(keys) (N * 0x2,)
     s_values = @localmem eltype(values) (N * 0x2,)
 


### PR DESCRIPTION
Since AcceleratedKernels.jl doesn't use the CPU backend of KernelAbstractions this hasn't caused issues before,
but technically the using a variable name like `N` in a `@localmem` statement requires `N` to be uniform across
the work-group.
