### PR TITLE
reduce doesn't query src backend if backend specified

### DIFF
--- a/src/reduce/mapreduce_1d.jl
+++ b/src/reduce/mapreduce_1d.jl
@@ -125,14 +125,14 @@ function mapreduce_1d(
     blocks = (len + num_per_block - 1) ÷ num_per_block
 
     if !isnothing(temp)
-        @argcheck get_backend(temp) === get_backend(src)
+        @argcheck get_backend(temp) === backend
         @argcheck eltype(temp) === typeof(init)
         @argcheck length(temp) >= blocks * 2
         dst = temp
     else
         # Figure out type for destination
         dst_type = typeof(init)
-        dst = similar(src, dst_type, blocks * 2)
+        dst = KernelAbstractions.allocate(backend, dst_type, blocks * 2)
     end
 
     # Later the kernel will be compiled for views anyways, so use same types


### PR DESCRIPTION
This allows calling reduce on MappedArrays types.  That's nice because you can avoid allocating a large array to store the input.  For example,

    julia> using AcceleratedKernels, CUDA, MappedArrays
    julia> AcceleratedKernels.sum(mappedarray(sin, 1:10_000_000_000), CUDABackend(false,false))

I'm creating a bare-bones pull request to get feedback on whether this is desired.  If so, I can add a unit test.