### PR TITLE
Remove GPUArrays dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.3.4"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
-GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
@@ -21,7 +21,7 @@ AcceleratedKernelsoneAPIExt = "oneAPI"
 
 [compat]
 ArgCheck = "2"
-GPUArrays = "10, 11"
+GPUArraysCore = "0.2.0"
 KernelAbstractions = "0.9.34"
 Markdown = "1"
 Metal = "1"

--- a/src/AcceleratedKernels.jl
+++ b/src/AcceleratedKernels.jl
@@ -12,7 +12,7 @@ module AcceleratedKernels
 
 # Internal dependencies
 using ArgCheck: @argcheck
-using GPUArrays: GPUArrays, AbstractGPUVector, AbstractGPUArray, @allowscalar
+using GPUArraysCore: GPUArrays, AbstractGPUVector, AbstractGPUArray, @allowscalar
 using KernelAbstractions
 using Polyester: @batch
 import OhMyThreads as OMT
@@ -21,7 +21,6 @@ import OhMyThreads as OMT
 # Exposed functions from upstream packages
 const synchronize = KernelAbstractions.synchronize
 const get_backend = KernelAbstractions.get_backend
-const neutral_element = GPUArrays.neutral_element
 
 
 # Include code from other files

--- a/src/AcceleratedKernels.jl
+++ b/src/AcceleratedKernels.jl
@@ -12,7 +12,7 @@ module AcceleratedKernels
 
 # Internal dependencies
 using ArgCheck: @argcheck
-using GPUArraysCore: GPUArrays, AbstractGPUVector, AbstractGPUArray, @allowscalar
+using GPUArraysCore: AbstractGPUVector, AbstractGPUArray, @allowscalar
 using KernelAbstractions
 using Polyester: @batch
 import OhMyThreads as OMT

--- a/src/accumulate/accumulate.jl
+++ b/src/accumulate/accumulate.jl
@@ -31,7 +31,7 @@ include("accumulate_cpu.jl")
     accumulate!(
         op, v::AbstractArray, backend::Backend=get_backend(v);
         init,
-        neutral=GPUArrays.neutral_element(op, eltype(v)),
+        neutral=neutral_element(op, eltype(v)),
         dims::Union{Nothing, Int}=nothing,
         inclusive::Bool=true,
 
@@ -47,7 +47,7 @@ include("accumulate_cpu.jl")
     accumulate!(
         op, dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(v);
         init,
-        neutral=GPUArrays.neutral_element(op, eltype(dst)),
+        neutral=neutral_element(op, eltype(dst)),
         dims::Union{Nothing, Int}=nothing,
         inclusive::Bool=true,
 
@@ -117,7 +117,7 @@ AK.accumulate!(+, v, alg=AK.ScanPrefixes())
 function accumulate!(
     op, v::AbstractArray, backend::Backend=get_backend(v);
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(v)),
+    neutral=neutral_element(op, eltype(v)),
     dims::Union{Nothing, Int}=nothing,
     inclusive::Bool=true,
 
@@ -141,7 +141,7 @@ end
 function accumulate!(
     op, dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(v);
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(dst)),
+    neutral=neutral_element(op, eltype(dst)),
     dims::Union{Nothing, Int}=nothing,
     inclusive::Bool=true,
 
@@ -166,7 +166,7 @@ end
 function _accumulate_impl!(
     op, v::AbstractArray, backend::Backend;
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(v)),
+    neutral=neutral_element(op, eltype(v)),
     dims::Union{Nothing, Int}=nothing,
     inclusive::Bool=true,
 
@@ -211,7 +211,7 @@ end
     accumulate(
         op, v::AbstractArray, backend::Backend=get_backend(v);
         init,
-        neutral=GPUArrays.neutral_element(op, eltype(v)),
+        neutral=neutral_element(op, eltype(v)),
         dims::Union{Nothing, Int}=nothing,
         inclusive::Bool=true,
 
@@ -229,7 +229,7 @@ Out-of-place version of [`accumulate!`](@ref).
 function accumulate(
     op, v::AbstractArray, backend::Backend=get_backend(v);
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(v)),
+    neutral=neutral_element(op, eltype(v)),
     dims::Union{Nothing, Int}=nothing,
     inclusive::Bool=true,
 

--- a/src/accumulate/accumulate_nd.jl
+++ b/src/accumulate/accumulate_nd.jl
@@ -254,7 +254,7 @@ end
 function accumulate_nd!(
     op, v::AbstractArray, backend::GPU;
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(v)),
+    neutral=neutral_element(op, eltype(v)),
     dims::Int,
     inclusive::Bool=true,
 

--- a/src/reduce/mapreduce_1d.jl
+++ b/src/reduce/mapreduce_1d.jl
@@ -102,7 +102,7 @@ end
 function mapreduce_1d(
     f, op, src::AbstractArray, backend::GPU;
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(src)),
+    neutral=neutral_element(op, eltype(src)),
 
     block_size::Int=256,
     temp::Union{Nothing, AbstractArray}=nothing,

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -188,7 +188,7 @@ end
 function mapreduce_nd(
     f, op, src::AbstractArray, backend::GPU;
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(src)),
+    neutral=neutral_element(op, eltype(src)),
     dims::Int,
     block_size::Int=256,
     temp::Union{Nothing, AbstractArray}=nothing,
@@ -324,7 +324,7 @@ end
 function _mapreduce_nd_apply_init!(f, op, dst, src, backend, init, block_size)
     foreachindex(
         dst, backend,
-        block_size=block_size,    
+        block_size=block_size,
     ) do i
         dst[i] = op(init, f(src[i]))
     end

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -1,3 +1,18 @@
+# neutral_element moved over from GPUArrays.jl
+neutral_element(op, T) =
+    error("""AcceleratedKernels.jl needs to know the neutral element for your operator `$op`.
+             Please pass it as an explicit keyword argument `neutral`.""")
+neutral_element(::typeof(Base.:(|)), T) = zero(T)
+neutral_element(::typeof(Base.:(+)), T) = zero(T)
+neutral_element(::typeof(Base.add_sum), T) = zero(T)
+neutral_element(::typeof(Base.:(&)), T) = one(T)
+neutral_element(::typeof(Base.:(*)), T) = one(T)
+neutral_element(::typeof(Base.mul_prod), T) = one(T)
+neutral_element(::typeof(Base.min), T) = typemax(T)
+neutral_element(::typeof(Base.max), T) = typemin(T)
+neutral_element(::typeof(Base._extrema_rf), ::Type{<:NTuple{2,T}}) where {T} = typemax(T), typemin(T)
+
+
 include("mapreduce_1d.jl")
 include("mapreduce_nd.jl")
 
@@ -6,7 +21,7 @@ include("mapreduce_nd.jl")
     reduce(
         op, src::AbstractArray, backend::Backend=get_backend(src);
         init,
-        neutral=GPUArrays.neutral_element(op, eltype(src)),
+        neutral=neutral_element(op, eltype(src)),
         dims::Union{Nothing, Int}=nothing,
 
         # CPU settings
@@ -72,7 +87,7 @@ mcolsum = AK.reduce(+, m; init=zero(eltype(m)), dims=2)
 function reduce(
     op, src::AbstractArray, backend::Backend=get_backend(src);
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(src)),
+    neutral=neutral_element(op, eltype(src)),
     dims::Union{Nothing, Int}=nothing,
 
     # CPU settings
@@ -103,7 +118,7 @@ end
 function _reduce_impl(
     op, src::AbstractArray, backend;
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(src)),
+    neutral=neutral_element(op, eltype(src)),
     dims::Union{Nothing, Int}=nothing,
 
     # CPU settings
@@ -137,7 +152,7 @@ end
     mapreduce(
         f, op, src::AbstractArray, backend::Backend=get_backend(src);
         init,
-        neutral=GPUArrays.neutral_element(op, eltype(src)),
+        neutral=neutral_element(op, eltype(src)),
         dims::Union{Nothing, Int}=nothing,
 
         # CPU settings
@@ -203,7 +218,7 @@ mcolsumsq = AK.mapreduce(f, +, m; init=zero(eltype(m)), dims=2)
 function mapreduce(
     f, op, src::AbstractArray, backend::Backend=get_backend(src);
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(src)),
+    neutral=neutral_element(op, eltype(src)),
     dims::Union{Nothing, Int}=nothing,
 
     # CPU settings
@@ -234,7 +249,7 @@ end
 function _mapreduce_impl(
     f, op, src::AbstractArray, backend::Backend;
     init,
-    neutral=GPUArrays.neutral_element(op, eltype(src)),
+    neutral=neutral_element(op, eltype(src)),
     dims::Union{Nothing, Int}=nothing,
 
     # CPU settings

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1395,7 +1395,7 @@ end
             n3 = rand(1:100)
             vh = rand(Float32, n1, n2, n3)
             v = array_from_host(vh)
-            
+
             s = AK.accumulate(+, v; init=Float32(0), dims=dims)
             sh = Array(s)
             @test all(sh .≈ accumulate(+, vh, init=Float32(0), dims=dims))
@@ -1530,7 +1530,7 @@ end
     AK.searchsortedfirst(v, x, by=abs, lt=(>), rev=true, block_size=64)
     AK.searchsortedlast!(ix, v, x, by=abs, lt=(>), rev=true, block_size=64)
     AK.searchsortedlast(v, x, by=abs, lt=(>), rev=true, block_size=64)
- 
+
     vh = Array(v)
     xh = Array(x)
     ixh = similar(xh, Int32)
@@ -1771,7 +1771,9 @@ end
     for _ in 1:100
         num_elems = rand(1:100_000)
         v = array_from_host(rand(Float32, num_elems))
-        @test AK.count(x->x>0.5, v) == count(x->x>0.5, Array(v))
+        gpucount = AK.count(x->x>0.5, v)
+        cpucount = count(x->x>0.5, Array(v))
+        @test gpucount == cpucount
     end
 
     for _ in 1:100
@@ -1809,7 +1811,7 @@ end
 
 
 @testset "cumsum" begin
-    
+
     Random.seed!(0)
 
     # Simple correctness tests
@@ -1858,7 +1860,7 @@ end
 
 
 @testset "cumprod" begin
-    
+
     Random.seed!(0)
 
     # Simple correctness tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1395,7 +1395,7 @@ end
             n3 = rand(1:100)
             vh = rand(Float32, n1, n2, n3)
             v = array_from_host(vh)
-
+            
             s = AK.accumulate(+, v; init=Float32(0), dims=dims)
             sh = Array(s)
             @test all(sh .≈ accumulate(+, vh, init=Float32(0), dims=dims))
@@ -1530,7 +1530,7 @@ end
     AK.searchsortedfirst(v, x, by=abs, lt=(>), rev=true, block_size=64)
     AK.searchsortedlast!(ix, v, x, by=abs, lt=(>), rev=true, block_size=64)
     AK.searchsortedlast(v, x, by=abs, lt=(>), rev=true, block_size=64)
-
+ 
     vh = Array(v)
     xh = Array(x)
     ixh = similar(xh, Int32)
@@ -1771,9 +1771,7 @@ end
     for _ in 1:100
         num_elems = rand(1:100_000)
         v = array_from_host(rand(Float32, num_elems))
-        gpucount = AK.count(x->x>0.5, v)
-        cpucount = count(x->x>0.5, Array(v))
-        @test gpucount == cpucount
+        @test AK.count(x->x>0.5, v) == count(x->x>0.5, Array(v))
     end
 
     for _ in 1:100
@@ -1811,7 +1809,7 @@ end
 
 
 @testset "cumsum" begin
-
+    
     Random.seed!(0)
 
     # Simple correctness tests
@@ -1860,7 +1858,7 @@ end
 
 
 @testset "cumprod" begin
-
+    
     Random.seed!(0)
 
     # Simple correctness tests


### PR DESCRIPTION
This moves the `neutral_element` definitions here and return to a `GPUArraysCore` dependency.

Will close if we don't end up going with this solution.

I would also suggest changing the docstrings from 
```
...
neutral=neutral_element(blah),
...
```

to 
```
...
[neutral],
...
```
since `neutral_element` isn't exported.