### PR TITLE
[Metal] Use safe `block_size` in `accumulate`

### DIFF
--- a/ext/AcceleratedKernelsMetalExt.jl
+++ b/ext/AcceleratedKernelsMetalExt.jl
@@ -18,7 +18,7 @@ function AK.accumulate!(
     alg::AK.AccumulateAlgorithm=AK.ScanPrefixes(),
 
     # GPU settings
-    block_size::Int=1024,
+    block_size::Int=256,
     temp::Union{Nothing, AbstractArray}=nothing,
     temp_flags::Union{Nothing, AbstractArray}=nothing,
 )
@@ -43,7 +43,7 @@ function AK.accumulate!(
     alg::AK.AccumulateAlgorithm=AK.ScanPrefixes(),
 
     # GPU settings
-    block_size::Int=1024,
+    block_size::Int=256,
     temp::Union{Nothing, AbstractArray}=nothing,
     temp_flags::Union{Nothing, AbstractArray}=nothing,
 )


### PR DESCRIPTION
1024 is the hard maximum number of threads per threadgroup, but the actual maximum depends on the `maxTotalThreadsPerThreadgroup` property of the kernel's `MTLComputePipelineState`. This makes always attempting to create a block/threadgroup with 1024 will cause errors in some situations.

This PR sets `block_size` to 256 like with all the other algorithms as a safe value.

As an example, the last failure in https://github.com/JuliaGPU/Metal.jl/pull/590 is because of this.