### PR TITLE
Add `dims` support to `reverse` and `reverse!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ If you need other algorithms in your work that may be of general use, please ope
 | [Binary Search](https://juliagpu.github.io/AcceleratedKernels.jl/stable/api/binarysearch/) | `searchsortedfirst` `searchsortedfirst!`         | `std::lower_bound`                                        |
 |                                               | `searchsortedlast` `searchsortedlast!`           | `thrust::upper_bound`                                     |
 | [Find All](https://juliagpu.github.io/AcceleratedKernels.jl/stable/api/findall/) | `findall`                                        | `thrust::copy_if` `cub::DeviceSelect` `nonzero`           |
+| [Reverse](https://juliagpu.github.io/AcceleratedKernels.jl/stable/api/reverse/) | `reverse` `reverse!`                             | `thrust::reverse` `std::reverse` `flip`                   |
 | [Predicates](https://juliagpu.github.io/AcceleratedKernels.jl/stable/api/predicates/) | `all` `any`                                      |                                                           |
 | [Arithmetics](https://juliagpu.github.io/AcceleratedKernels.jl/stable/api/arithmetics/) | `sum` `prod` `minimum` `maximum` `count` `cumsum` `cumprod`                                      |                                                           |
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,6 +29,7 @@ makedocs(;
             "Accumulate" => "api/accumulate.md",
             "Binary Search" => "api/binarysearch.md",
             "Find All" => "api/findall.md",
+            "Reverse" => "api/reverse.md",
             "Predicates" => "api/predicates.md",
             "Arithmetics" => "api/arithmetics.md",
             "Custom Structs" => "api/custom_structs.md",

--- a/docs/src/api/reverse.md
+++ b/docs/src/api/reverse.md
@@ -1,0 +1,6 @@
+### Reverse
+
+```@docs
+AcceleratedKernels.reverse!
+AcceleratedKernels.reverse
+```

--- a/src/foreachindex.jl
+++ b/src/foreachindex.jl
@@ -6,9 +6,7 @@
     ithread = @index(Local, Linear)
     i = ithread + (iblock - 0x1) * N
 
-    # Force inlining: a closure capturing several arrays or index objects is otherwise called
-    # as a separate device function, with its captured state copied to local memory first,
-    # which costs 3-6x in bandwidth-bound loops on NVPTX
+    # Avoid an out-of-line device call that can copy captured state to local memory.
     if i <= length(indices)
         @inline f(indices[i])
     end

--- a/src/foreachindex.jl
+++ b/src/foreachindex.jl
@@ -6,8 +6,11 @@
     ithread = @index(Local, Linear)
     i = ithread + (iblock - 0x1) * N
 
+    # Force inlining: a closure capturing several arrays or index objects is otherwise called
+    # as a separate device function, with its captured state copied to local memory first,
+    # which costs 3-6x in bandwidth-bound loops on NVPTX
     if i <= length(indices)
-        f(indices[i])
+        @inline f(indices[i])
     end
 end
 

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -9,6 +9,8 @@ function _check_reverse_dims(A, dims)
     dims isa Colon && return
     applicable(iterate, dims) || throw(ArgumentError("dimension $dims is not iterable"))
     for d in dims                                       # an integer iterates once
+        d isa Integer ||
+            throw(ArgumentError("reversed dimension(s) must be integers, got $dims"))
         1 <= d <= ndims(A) ||
             throw(ArgumentError("dimension $dims is not 1 ≤ dims ≤ $(ndims(A))"))
     end
@@ -201,12 +203,7 @@ Prefer [`reverse!`](@ref) when you do not need to keep `v`; it avoids the alloca
 """
 function reverse(
     v::AbstractArray, backend::Backend=get_backend(v);
-    dims=:, kwargs...
+    kwargs...
 )
-    _check_reverse_dims(v, dims)
-    dst = similar(v)
-    if !(dims isa Colon)
-        return _reverse_dims!(dst, v, dims, backend; kwargs...)
-    end
-    reverse!(dst, v, backend; kwargs...)
+    reverse!(similar(v), v, backend; kwargs...)
 end

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -1,6 +1,78 @@
+# Reversing. Two regimes:
+#   * `dims=:` (default) reverses the whole array, a reversal of the column-major linear order,
+#     taken by the fast flat path below (swap mirrored pairs, no index arithmetic).
+#   * `dims=d` reverses only along those dimensions, via the general ND kernel below.
+
+
+# Validate `dims`: a `Colon`, an integer, or an iterable of integers within `1:ndims(A)`.
+function _check_reverse_dims(A, dims)
+    dims isa Colon && return
+    applicable(iterate, dims) || throw(ArgumentError("dimension $dims is not iterable"))
+    for d in dims                                       # an integer iterates once
+        1 <= d <= ndims(A) ||
+            throw(ArgumentError("dimension $dims is not 1 ≤ dims ≤ $(ndims(A))"))
+    end
+    return
+end
+
+
+# In-place: split along the last non-singleton reversed dim so only ~half the elements need a
+# thread, each swapping with its mirror.
+function _reverse_dims!(
+    v::AbstractArray{T, N}, dims, backend;
+    kwargs...
+) where {T, N}
+    rev_dims = ntuple(d -> (d in dims) && size(v, d) > 1, N)
+    half_dim = findlast(rev_dims)
+    isnothing(half_dim) && return v         # all reversed dims are singletons
+
+    ref = size(v) .+ 1
+    lin_idx = LinearIndices(v)
+    reduced_size = ntuple(d -> ifelse(d == half_dim, cld(size(v, d), 2), size(v, d)), N)
+    nd_idx = CartesianIndices(reduced_size)
+
+    foreachindex(1:Base.prod(reduced_size), backend; kwargs...) do i
+        idx = Tuple(nd_idx[i])
+        index_in = lin_idx[idx...]
+        idx_mirror = ifelse.(rev_dims, ref .- idx, idx)
+        index_out = lin_idx[idx_mirror...]
+        @inbounds if index_in < index_out
+            temp = v[index_out]
+            v[index_out] = v[index_in]
+            v[index_in] = temp
+        end
+    end
+
+    v
+end
+
+
+# Out-of-place: one thread per element copies `src[i]` to its mirror slot.
+function _reverse_dims!(
+    dst::AbstractArray{T, N}, src::AbstractArray{T, N}, dims, backend;
+    kwargs...
+) where {T, N}
+    rev_dims = ntuple(d -> (d in dims) && size(src, d) > 1, N)
+    ref = size(src) .+ 1
+    lin_idx = LinearIndices(src)
+    nd_idx = CartesianIndices(src)
+
+    foreachindex(src, backend; kwargs...) do i
+        idx = Tuple(nd_idx[i])
+        idx_mirror = ifelse.(rev_dims, ref .- idx, idx)
+        index_out = lin_idx[idx_mirror...]
+        @inbounds dst[index_out] = src[i]
+    end
+
+    dst
+end
+
+
 """
     reverse!(
         v::AbstractArray, backend::Backend=get_backend(v);
+
+        dims=:,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -10,12 +82,15 @@
         block_size=256,
     )
 
-Reverse `v` in-place and return it. The CPU and GPU settings are the same as for
-[`foreachindex`](@ref).
+Reverse `v` in-place and return it. With `dims=:` (the default) the whole array is reversed; pass
+`dims=d` (an integer or an iterable of integers) to reverse only along those dimensions, matching
+`Base.reverse!`. The CPU and GPU settings are the same as for [`foreachindex`](@ref).
 
-Each thread swaps one symmetric pair `v[i] <-> v[end - i + 1]`, so only `length(v) ÷ 2` threads
-are launched and no temporary array is allocated. Arrays of odd length keep their middle element
-in place.
+For the whole-array case each thread swaps one symmetric pair `v[i] <-> v[end - i + 1]`, so only
+`length(v) ÷ 2` threads are launched and no temporary array is allocated. Arrays of odd length keep
+their middle element in place.
+
+To reverse a contiguous sub-range of a vector, reverse a view: `AK.reverse!(@view v[lo:hi])`.
 
 # Examples
 ```julia
@@ -24,19 +99,27 @@ import AcceleratedKernels as AK
 
 v = CUDA.CuArray(1:100_000)
 AK.reverse!(v)
+
+m = CUDA.CuArray(reshape(1:12, 3, 4))
+AK.reverse!(m; dims=2)          # reverse the columns
 ```
 """
 function reverse!(
     v::AbstractArray, backend::Backend=get_backend(v);
-    kwargs...
+    dims=:, kwargs...
 )
+    _check_reverse_dims(v, dims)
+    if !(dims isa Colon)
+        return _reverse_dims!(v, dims, backend; kwargs...)
+    end
+
     len = length(v)
     len <= 1 && return v
 
     lo = firstindex(v)
     hi = lastindex(v)
 
-    # Only the lower half needs threads - each one swaps its mirrored partner too; for odd
+    # Only the lower half needs threads, each swapping its mirrored partner too; for odd
     # lengths the middle element is its own mirror, so it is correctly left untouched
     foreachindex(1:(len ÷ 2), backend; kwargs...) do i
         left = lo + i - 1
@@ -56,6 +139,8 @@ end
     reverse!(
         dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
 
+        dims=:,
+
         # CPU settings
         max_tasks=Threads.nthreads(),
         min_elems=1,
@@ -65,13 +150,21 @@ end
     )
 
 Write the reverse of `src` into `dst` and return `dst`; `src` is left unchanged. `dst` and `src`
-must have the same length and must not alias. The CPU and GPU settings are the same as for
+must have the same size and must not alias. With `dims=:` (the default) the whole array is reversed;
+pass `dims=d` to reverse only along those dimensions. The CPU and GPU settings are the same as for
 [`foreachindex`](@ref).
 """
 function reverse!(
     dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
-    kwargs...
+    dims=:, kwargs...
 )
+    _check_reverse_dims(src, dims)
+    if !(dims isa Colon)
+        @argcheck size(dst) == size(src)
+        length(src) == 0 && return dst
+        return _reverse_dims!(dst, src, dims, backend; kwargs...)
+    end
+
     @argcheck length(dst) == length(src)
     length(src) == 0 && return dst
 
@@ -90,6 +183,8 @@ end
     reverse(
         v::AbstractArray, backend::Backend=get_backend(v);
 
+        dims=:,
+
         # CPU settings
         max_tasks=Threads.nthreads(),
         min_elems=1,
@@ -98,15 +193,20 @@ end
         block_size=256,
     )
 
-Return a reversed copy of `v`, leaving `v` unchanged. The CPU and GPU settings are the same as for
-[`foreachindex`](@ref).
+Return a reversed copy of `v`, leaving `v` unchanged. With `dims=:` (the default) the whole array is
+reversed; pass `dims=d` to reverse only along those dimensions, matching `Base.reverse`. The CPU and
+GPU settings are the same as for [`foreachindex`](@ref).
 
-Prefer [`reverse!`](@ref) when you do not need to keep `v` - it avoids the allocation.
+Prefer [`reverse!`](@ref) when you do not need to keep `v`; it avoids the allocation.
 """
 function reverse(
     v::AbstractArray, backend::Backend=get_backend(v);
-    kwargs...
+    dims=:, kwargs...
 )
+    _check_reverse_dims(v, dims)
     dst = similar(v)
+    if !(dims isa Colon)
+        return _reverse_dims!(dst, v, dims, backend; kwargs...)
+    end
     reverse!(dst, v, backend; kwargs...)
 end

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -1,6 +1,77 @@
+# Validate `dims`: a `Colon`, an integer, or an iterable of integers in `1:ndims(A)`.
+function check_reverse_dims(A, dims)
+    dims isa Colon && return
+    applicable(iterate, dims) ||
+        throw(ArgumentError("dims must be an integer, an iterable of integers, or `:`, got $dims"))
+    for d in dims                                       # an integer iterates once
+        d isa Integer ||
+            throw(ArgumentError("dims must be integers, got $dims"))
+        1 <= d <= ndims(A) ||
+            throw(ArgumentError("dimension $d is out of range 1:$(ndims(A))"))
+    end
+    return
+end
+
+
+# In-place reversal along `dims`. Only half the elements need a thread, each swapping with its
+# mirror image; the array is split along the last non-singleton reversed dimension. For odd
+# sizes the middle slice mirrors onto itself and the `index_in < index_out` guard makes sure
+# each pair in it is swapped once.
+function reverse_dims!(
+    v::AbstractArray{T, N}, dims, backend;
+    kwargs...
+) where {T, N}
+    rev_dims = ntuple(d -> (d in dims) && size(v, d) > 1, N)
+    half_dim = findlast(rev_dims)
+    isnothing(half_dim) && return v         # all reversed dims are singletons
+
+    ref = size(v) .+ 1
+    lin_idx = LinearIndices(v)
+    reduced_size = ntuple(d -> ifelse(d == half_dim, cld(size(v, d), 2), size(v, d)), N)
+    nd_idx = CartesianIndices(reduced_size)
+
+    foreachindex(1:Base.prod(reduced_size), backend; kwargs...) do i
+        idx = Tuple(nd_idx[i])
+        index_in = lin_idx[idx...]
+        idx_mirror = ifelse.(rev_dims, ref .- idx, idx)
+        index_out = lin_idx[idx_mirror...]
+        @inbounds if index_in < index_out
+            temp = v[index_out]
+            v[index_out] = v[index_in]
+            v[index_in] = temp
+        end
+    end
+
+    v
+end
+
+
+# Out-of-place reversal along `dims`: one thread per element copies `src[i]` to its mirror slot.
+function reverse_dims!(
+    dst::AbstractArray{T, N}, src::AbstractArray{T, N}, dims, backend;
+    kwargs...
+) where {T, N}
+    rev_dims = ntuple(d -> (d in dims) && size(src, d) > 1, N)
+    ref = size(src) .+ 1
+    lin_idx = LinearIndices(src)
+    nd_idx = CartesianIndices(src)
+
+    foreachindex(src, backend; kwargs...) do i
+        idx = Tuple(nd_idx[i])
+        idx_mirror = ifelse.(rev_dims, ref .- idx, idx)
+        index_out = lin_idx[idx_mirror...]
+        @inbounds dst[index_out] = src[i]
+    end
+
+    dst
+end
+
+
 """
     reverse!(
         v::AbstractArray, backend::Backend=get_backend(v);
+
+        dims=:,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -10,12 +81,15 @@
         block_size=256,
     )
 
-Reverse `v` in-place and return it. The CPU and GPU settings are the same as for
-[`foreachindex`](@ref).
+Reverse `v` in-place and return it. With `dims=:` (the default) the whole array is reversed; pass
+`dims=d` (an integer or an iterable of integers) to reverse only along those dimensions, matching
+`Base.reverse!`. The CPU and GPU settings are the same as for [`foreachindex`](@ref).
 
-Each thread swaps one symmetric pair `v[i] <-> v[end - i + 1]`, so only `length(v) ÷ 2` threads
-are launched and no temporary array is allocated. Arrays of odd length keep their middle element
-in place.
+For the whole-array case each thread swaps one symmetric pair `v[i] <-> v[end - i + 1]`, so only
+`length(v) ÷ 2` threads are launched and no temporary array is allocated. Arrays of odd length keep
+their middle element in place.
+
+To reverse a contiguous sub-range of a vector, reverse a view: `AK.reverse!(@view v[lo:hi])`.
 
 # Examples
 ```julia
@@ -24,19 +98,27 @@ import AcceleratedKernels as AK
 
 v = CUDA.CuArray(1:100_000)
 AK.reverse!(v)
+
+m = CUDA.CuArray(reshape(1:12, 3, 4))
+AK.reverse!(m; dims=2)          # reverse the columns
 ```
 """
 function reverse!(
     v::AbstractArray, backend::Backend=get_backend(v);
-    kwargs...
+    dims=:, kwargs...
 )
+    check_reverse_dims(v, dims)
+    if !(dims isa Colon)
+        return reverse_dims!(v, dims, backend; kwargs...)
+    end
+
     len = length(v)
     len <= 1 && return v
 
     lo = firstindex(v)
     hi = lastindex(v)
 
-    # Only the lower half needs threads - each one swaps its mirrored partner too; for odd
+    # Only the lower half needs threads, each swapping its mirrored partner too; for odd
     # lengths the middle element is its own mirror, so it is correctly left untouched
     foreachindex(1:(len ÷ 2), backend; kwargs...) do i
         left = lo + i - 1
@@ -56,6 +138,8 @@ end
     reverse!(
         dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
 
+        dims=:,
+
         # CPU settings
         max_tasks=Threads.nthreads(),
         min_elems=1,
@@ -65,13 +149,21 @@ end
     )
 
 Write the reverse of `src` into `dst` and return `dst`; `src` is left unchanged. `dst` and `src`
-must have the same length and must not alias. The CPU and GPU settings are the same as for
+must have the same size and must not alias. With `dims=:` (the default) the whole array is reversed;
+pass `dims=d` to reverse only along those dimensions. The CPU and GPU settings are the same as for
 [`foreachindex`](@ref).
 """
 function reverse!(
     dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
-    kwargs...
+    dims=:, kwargs...
 )
+    check_reverse_dims(src, dims)
+    if !(dims isa Colon)
+        @argcheck size(dst) == size(src)
+        length(src) == 0 && return dst
+        return reverse_dims!(dst, src, dims, backend; kwargs...)
+    end
+
     @argcheck length(dst) == length(src)
     length(src) == 0 && return dst
 
@@ -90,6 +182,8 @@ end
     reverse(
         v::AbstractArray, backend::Backend=get_backend(v);
 
+        dims=:,
+
         # CPU settings
         max_tasks=Threads.nthreads(),
         min_elems=1,
@@ -98,15 +192,15 @@ end
         block_size=256,
     )
 
-Return a reversed copy of `v`, leaving `v` unchanged. The CPU and GPU settings are the same as for
-[`foreachindex`](@ref).
+Return a reversed copy of `v`, leaving `v` unchanged. With `dims=:` (the default) the whole array is
+reversed; pass `dims=d` to reverse only along those dimensions, matching `Base.reverse`. The CPU and
+GPU settings are the same as for [`foreachindex`](@ref).
 
-Prefer [`reverse!`](@ref) when you do not need to keep `v` - it avoids the allocation.
+Prefer [`reverse!`](@ref) when you do not need to keep `v`; it avoids the allocation.
 """
 function reverse(
     v::AbstractArray, backend::Backend=get_backend(v);
     kwargs...
 )
-    dst = similar(v)
-    reverse!(dst, v, backend; kwargs...)
+    reverse!(similar(v), v, backend; kwargs...)
 end

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -1,31 +1,29 @@
-# Validate `dims`: a `Colon`, an integer, or an iterable of distinct integers in `1:ndims(A)`,
-# the same contract as `Base.reverse`.
+# Materialize iterators once so validation does not consume the dimensions used by the loop.
 function check_reverse_dims(A, dims)
-    dims isa Colon && return
+    dims isa Colon && return dims
     applicable(iterate, dims) ||
         throw(ArgumentError("dims must be an integer, an iterable of integers, or `:`, got $dims"))
-    for d in dims                                       # an integer iterates once
+    dims = Tuple(dims)
+    for d in dims
         d isa Integer ||
             throw(ArgumentError("dims must be integers, got $dims"))
         1 <= d <= ndims(A) ||
             throw(ArgumentError("dimension $d is out of range 1:$(ndims(A))"))
     end
     allunique(dims) || throw(ArgumentError("dims $dims contains duplicates"))
-    return
+    return dims
 end
 
 
-# In-place reversal along `dims`. Only half the elements need a thread, each swapping with its
-# mirror image; the array is split along the last non-singleton reversed dimension. For odd
-# sizes the middle slice mirrors onto itself and the `index_in < index_out` guard makes sure
-# each pair in it is swapped once.
+# Split along the last non-singleton reversed dimension. For odd extents, the middle
+# slice mirrors onto itself; the index ordering guard swaps each pair in it only once.
 function reverse_dims!(
     v::AbstractArray{T, N}, dims, backend;
     kwargs...
 ) where {T, N}
     rev_dims = ntuple(d -> (d in dims) && size(v, d) > 1, N)
     half_dim = findlast(rev_dims)
-    isnothing(half_dim) && return v         # all reversed dims are singletons
+    isnothing(half_dim) && return v
 
     ref = size(v) .+ 1
     lin_idx = LinearIndices(v)
@@ -48,9 +46,8 @@ function reverse_dims!(
 end
 
 
-# Out-of-place reversal along `dims`: one thread per element copies `src[i]` to its mirror slot.
 function reverse_dims!(
-    dst::AbstractArray{T, N}, src::AbstractArray{T, N}, dims, backend;
+    dst::AbstractArray, src::AbstractArray{T, N}, dims, backend;
     kwargs...
 ) where {T, N}
     rev_dims = ntuple(d -> (d in dims) && size(src, d) > 1, N)
@@ -84,12 +81,11 @@ end
     )
 
 Reverse `v` in-place and return it. With `dims=:` (the default) the whole array is reversed; pass
-`dims=d` (an integer or an iterable of integers) to reverse only along those dimensions, matching
-`Base.reverse!`. The CPU and GPU settings are the same as for [`foreachindex`](@ref).
+`dims=d` (an integer or an iterable of distinct integers in `1:ndims(v)`) to reverse only along
+those dimensions. `dims=()` leaves `v` unchanged. The CPU and GPU settings are the same as for
+[`foreachindex`](@ref).
 
-For the whole-array case each thread swaps one symmetric pair `v[i] <-> v[end - i + 1]`, so only
-`length(v) ÷ 2` threads are launched and no temporary array is allocated. Arrays of odd length keep
-their middle element in place.
+No temporary array is allocated.
 
 To reverse a contiguous sub-range of a vector, reverse a view: `AK.reverse!(@view v[lo:hi])`.
 
@@ -109,7 +105,7 @@ function reverse!(
     v::AbstractArray, backend::Backend=get_backend(v);
     dims=:, kwargs...
 )
-    check_reverse_dims(v, dims)
+    dims = check_reverse_dims(v, dims)
     if !(dims isa Colon)
         return reverse_dims!(v, dims, backend; kwargs...)
     end
@@ -120,8 +116,7 @@ function reverse!(
     lo = firstindex(v)
     hi = lastindex(v)
 
-    # Only the lower half needs threads, each swapping its mirrored partner too; for odd
-    # lengths the middle element is its own mirror, so it is correctly left untouched
+    # Swap each pair once; an odd-length array keeps its middle element.
     foreachindex(1:(len ÷ 2), backend; kwargs...) do i
         left = lo + i - 1
         right = hi - i + 1
@@ -151,15 +146,16 @@ end
     )
 
 Write the reverse of `src` into `dst` and return `dst`; `src` is left unchanged. `dst` and `src`
-must have the same size and must not alias. With `dims=:` (the default) the whole array is reversed;
-pass `dims=d` to reverse only along those dimensions. The CPU and GPU settings are the same as for
-[`foreachindex`](@ref).
+must not alias. With `dims=:` (the default), the whole array is reversed and only the lengths
+must match. With an integer or iterable of distinct dimensions, the sizes must match. `dims=()`
+copies `src` unchanged. Elements are converted to the destination element type on assignment.
+The CPU and GPU settings are the same as for [`foreachindex`](@ref).
 """
 function reverse!(
     dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
     dims=:, kwargs...
 )
-    check_reverse_dims(src, dims)
+    dims = check_reverse_dims(src, dims)
     if !(dims isa Colon)
         @argcheck size(dst) == size(src)
         length(src) == 0 && return dst

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -1,4 +1,5 @@
-# Validate `dims`: a `Colon`, an integer, or an iterable of integers in `1:ndims(A)`.
+# Validate `dims`: a `Colon`, an integer, or an iterable of distinct integers in `1:ndims(A)`,
+# the same contract as `Base.reverse`.
 function check_reverse_dims(A, dims)
     dims isa Colon && return
     applicable(iterate, dims) ||
@@ -9,6 +10,7 @@ function check_reverse_dims(A, dims)
         1 <= d <= ndims(A) ||
             throw(ArgumentError("dimension $d is out of range 1:$(ndims(A))"))
     end
+    allunique(dims) || throw(ArgumentError("dims $dims contains duplicates"))
     return
 end
 

--- a/test/generic/reverse.jl
+++ b/test/generic/reverse.jl
@@ -91,4 +91,78 @@
             @test Array(v) == reverse(h)
         end
     end
+
+    # N-dimensional reversal along a subset of dimensions (Base.reverse parity)
+    @testset "dims" begin
+        # Single dimension, including a degenerate size-1 dim and a large 3-D array
+        for shape in ([1, 2, 4, 3], [4, 2], [5], [8, 8, 8]),
+            dim in 1:length(shape)
+
+            h = rand(Float32, shape...)
+
+            v = array_from_host(h)
+            AK.reverse!(v; dims=dim, prefer_threads)
+            @test Array(v) == reverse(h; dims=dim)
+
+            src = array_from_host(h)
+            out = AK.reverse(src; dims=dim, prefer_threads)
+            @test Array(out) == reverse(h; dims=dim)
+            @test Array(src) == h                       # source left untouched
+
+            dst = array_from_host(zeros(Float32, shape...))
+            AK.reverse!(dst, src; dims=dim, prefer_threads)
+            @test Array(dst) == reverse(h; dims=dim)
+        end
+
+        # Multiple dimensions at once, plus dims=: (dispatches to the flat whole-array path).
+        # The odd sizes of [7, 6, 5] exercise the in-place middle-plane swaps, where only the
+        # index ordering guard stops a pair from being swapped twice
+        for shape in ([1, 2, 4, 3], [8, 8, 8], [7, 6, 5]),
+            dims in ((1, 2), (2, 3), (1, 3), :)
+
+            h = rand(Float32, shape...)
+
+            v = array_from_host(h)
+            AK.reverse!(v; dims=dims, prefer_threads)
+            @test Array(v) == reverse(h; dims=dims)
+
+            out = AK.reverse(array_from_host(h); dims=dims, prefer_threads)
+            @test Array(out) == reverse(h; dims=dims)
+
+            src = array_from_host(h)
+            dst = array_from_host(zeros(Float32, shape...))
+            AK.reverse!(dst, src; dims=dims, prefer_threads)
+            @test Array(dst) == reverse(h; dims=dims)
+        end
+
+        # Any iterable of integers works, e.g. a Vector (Base only accepts tuples)
+        h = rand(Float32, 4, 5, 6)
+        out = AK.reverse(array_from_host(h); dims=[1, 3], prefer_threads)
+        @test Array(out) == reverse(h; dims=(1, 3))
+
+        # Empty arrays are returned unchanged
+        h = zeros(Float32, 0, 5)
+        for dims in (1, 2, (1, 2))
+            v = array_from_host(h)
+            @test Array(AK.reverse!(v; dims, prefer_threads)) == reverse(h; dims)
+
+            dst = array_from_host(copy(h))
+            @test Array(AK.reverse!(dst, v; dims, prefer_threads)) == reverse(h; dims)
+
+            @test Array(AK.reverse(v; dims, prefer_threads)) == reverse(h; dims)
+        end
+    end
+
+    # Invalid dims arguments throw, matching Base/CUDA
+    @testset "dims errors" begin
+        v = array_from_host(rand(Float32, 2, 3, 4))
+        @test_throws ArgumentError AK.reverse!(v; dims=0, prefer_threads)
+        @test_throws ArgumentError AK.reverse!(v; dims=4, prefer_threads)
+        @test_throws ArgumentError AK.reverse(v; dims=0, prefer_threads)
+        @test_throws ArgumentError AK.reverse(v; dims=4, prefer_threads)
+
+        # Non-integer dims must throw rather than silently do nothing
+        @test_throws ArgumentError AK.reverse!(v; dims=1.5, prefer_threads)
+        @test_throws ArgumentError AK.reverse(v; dims=(1, 2.5), prefer_threads)
+    end
 end

--- a/test/generic/reverse.jl
+++ b/test/generic/reverse.jl
@@ -91,4 +91,50 @@
             @test Array(v) == reverse(h)
         end
     end
+
+    # N-dimensional reversal along a subset of dimensions (Base.reverse parity)
+    @testset "dims" begin
+        # Single dimension, including a degenerate size-1 dim and a large 3-D array
+        for shape in ([1, 2, 4, 3], [4, 2], [5], [8, 8, 8]),
+            dim in 1:length(shape)
+
+            h = rand(Float32, shape...)
+
+            v = array_from_host(h)
+            AK.reverse!(v; dims=dim, prefer_threads)
+            @test Array(v) == reverse(h; dims=dim)
+
+            src = array_from_host(h)
+            out = AK.reverse(src; dims=dim, prefer_threads)
+            @test Array(out) == reverse(h; dims=dim)
+            @test Array(src) == h                       # source left untouched
+
+            dst = array_from_host(zeros(Float32, shape...))
+            AK.reverse!(dst, src; dims=dim, prefer_threads)
+            @test Array(dst) == reverse(h; dims=dim)
+        end
+
+        # Multiple dimensions at once, plus dims=: (whole-array through the general path)
+        for shape in ([1, 2, 4, 3], [8, 8, 8]),
+            dims in ((1, 2), (2, 3), (1, 3), :)
+
+            h = rand(Float32, shape...)
+
+            v = array_from_host(h)
+            AK.reverse!(v; dims=dims, prefer_threads)
+            @test Array(v) == reverse(h; dims=dims)
+
+            out = AK.reverse(array_from_host(h); dims=dims, prefer_threads)
+            @test Array(out) == reverse(h; dims=dims)
+        end
+    end
+
+    # Invalid dims arguments throw, matching Base/CUDA
+    @testset "dims errors" begin
+        v = array_from_host(rand(Float32, 2, 3, 4))
+        @test_throws ArgumentError AK.reverse!(v; dims=0, prefer_threads)
+        @test_throws ArgumentError AK.reverse!(v; dims=4, prefer_threads)
+        @test_throws ArgumentError AK.reverse(v; dims=0, prefer_threads)
+        @test_throws ArgumentError AK.reverse(v; dims=4, prefer_threads)
+    end
 end

--- a/test/generic/reverse.jl
+++ b/test/generic/reverse.jl
@@ -114,8 +114,10 @@
             @test Array(dst) == reverse(h; dims=dim)
         end
 
-        # Multiple dimensions at once, plus dims=: (whole-array through the general path)
-        for shape in ([1, 2, 4, 3], [8, 8, 8]),
+        # Multiple dimensions at once, plus dims=: (dispatches to the flat whole-array path).
+        # The odd sizes of [7, 6, 5] exercise the in-place middle-plane swaps, where only the
+        # index ordering guard stops a pair from being swapped twice
+        for shape in ([1, 2, 4, 3], [8, 8, 8], [7, 6, 5]),
             dims in ((1, 2), (2, 3), (1, 3), :)
 
             h = rand(Float32, shape...)
@@ -126,6 +128,28 @@
 
             out = AK.reverse(array_from_host(h); dims=dims, prefer_threads)
             @test Array(out) == reverse(h; dims=dims)
+
+            src = array_from_host(h)
+            dst = array_from_host(zeros(Float32, shape...))
+            AK.reverse!(dst, src; dims=dims, prefer_threads)
+            @test Array(dst) == reverse(h; dims=dims)
+        end
+
+        # Any iterable of integers works, e.g. a Vector (Base only accepts tuples)
+        h = rand(Float32, 4, 5, 6)
+        out = AK.reverse(array_from_host(h); dims=[1, 3], prefer_threads)
+        @test Array(out) == reverse(h; dims=(1, 3))
+
+        # Empty arrays are returned unchanged
+        h = zeros(Float32, 0, 5)
+        for dims in (1, 2, (1, 2))
+            v = array_from_host(h)
+            @test Array(AK.reverse!(v; dims, prefer_threads)) == reverse(h; dims)
+
+            dst = array_from_host(copy(h))
+            @test Array(AK.reverse!(dst, v; dims, prefer_threads)) == reverse(h; dims)
+
+            @test Array(AK.reverse(v; dims, prefer_threads)) == reverse(h; dims)
         end
     end
 
@@ -136,5 +160,9 @@
         @test_throws ArgumentError AK.reverse!(v; dims=4, prefer_threads)
         @test_throws ArgumentError AK.reverse(v; dims=0, prefer_threads)
         @test_throws ArgumentError AK.reverse(v; dims=4, prefer_threads)
+
+        # Non-integer dims must throw rather than silently do nothing
+        @test_throws ArgumentError AK.reverse!(v; dims=1.5, prefer_threads)
+        @test_throws ArgumentError AK.reverse(v; dims=(1, 2.5), prefer_threads)
     end
 end

--- a/test/generic/reverse.jl
+++ b/test/generic/reverse.jl
@@ -140,6 +140,25 @@
         out = AK.reverse(array_from_host(h); dims=[1, 3], prefer_threads)
         @test Array(out) == reverse(h; dims=(1, 3))
 
+        # dims=() reverses nothing
+        v = array_from_host(h)
+        @test Array(AK.reverse!(v; dims=(), prefer_threads)) == h
+        @test Array(AK.reverse(v; dims=(), prefer_threads)) == h
+
+        # Shapes spanning many blocks, with odd extents so the in-place middle slice is
+        # non-trivial, for integer element types too
+        for T in valid_backend_eltypes(BACKEND, (Int32, Float32)), shape in ((1001, 333), (33, 65, 129))
+            h = rand(T, shape)
+            for dims in (1, 2, (1, 2)), block_size in (64, 256)
+                v = array_from_host(h)
+                AK.reverse!(v; dims, prefer_threads, block_size)
+                @test Array(v) == reverse(h; dims)
+
+                out = AK.reverse(array_from_host(h); dims, prefer_threads, block_size)
+                @test Array(out) == reverse(h; dims)
+            end
+        end
+
         # Empty arrays are returned unchanged
         h = zeros(Float32, 0, 5)
         for dims in (1, 2, (1, 2))
@@ -164,5 +183,9 @@
         # Non-integer dims must throw rather than silently do nothing
         @test_throws ArgumentError AK.reverse!(v; dims=1.5, prefer_threads)
         @test_throws ArgumentError AK.reverse(v; dims=(1, 2.5), prefer_threads)
+
+        # Duplicate dims throw, as in Base
+        @test_throws ArgumentError AK.reverse!(v; dims=(1, 1), prefer_threads)
+        @test_throws ArgumentError AK.reverse(v; dims=[2, 3, 2], prefer_threads)
     end
 end

--- a/test/generic/reverse.jl
+++ b/test/generic/reverse.jl
@@ -140,6 +140,28 @@
         out = AK.reverse(array_from_host(h); dims=[1, 3], prefer_threads)
         @test Array(out) == reverse(h; dims=(1, 3))
 
+        # Stateful iterators must survive validation, including duplicate detection.
+        expected = reverse(h; dims=(1, 3))
+        v = array_from_host(h)
+        @test AK.reverse!(v; dims=Iterators.Stateful([1, 3]), prefer_threads) === v
+        @test Array(v) == expected
+        src = array_from_host(h)
+        @test Array(AK.reverse(src; dims=Iterators.Stateful([1, 3]), prefer_threads)) == expected
+        dst = similar(src)
+        @test AK.reverse!(dst, src; dims=Iterators.Stateful([1, 3]), prefer_threads) === dst
+        @test Array(dst) == expected
+        @test Array(src) == h
+
+        # Destination assignment converts element types, as in the whole-array path.
+        h_int = reshape(Int32.(1:30), 5, 6)
+        src_int = array_from_host(h_int)
+        for dims in (:, (), 1, (1, 2))
+            dst_float = array_from_host(zeros(Float32, size(h_int)))
+            @test AK.reverse!(dst_float, src_int; dims, prefer_threads) === dst_float
+            @test Array(dst_float) == reverse(h_int; dims)
+        end
+        @test Array(src_int) == h_int
+
         # dims=() reverses nothing
         v = array_from_host(h)
         @test Array(AK.reverse!(v; dims=(), prefer_threads)) == h
@@ -183,6 +205,11 @@
         # Non-integer dims must throw rather than silently do nothing
         @test_throws ArgumentError AK.reverse!(v; dims=1.5, prefer_threads)
         @test_throws ArgumentError AK.reverse(v; dims=(1, 2.5), prefer_threads)
+
+        dst = similar(v)
+        @test_throws ArgumentError AK.reverse!(dst, v; dims=Iterators.Stateful([1, 1]), prefer_threads)
+        @test_throws ArgumentError AK.reverse!(v; dims=nothing, prefer_threads)
+        @test_throws ArgumentError AK.reverse!(similar(v, 4, 3, 2), v; dims=1, prefer_threads)
 
         # Duplicate dims throw, as in Base
         @test_throws ArgumentError AK.reverse!(v; dims=(1, 1), prefer_threads)


### PR DESCRIPTION
Adds axis reversal on CPUs and GPUs through the existing AK API:

```julia-repl
julia> import AcceleratedKernels as AK

julia> A = [1 3 5; 2 4 6];

julia> AK.reverse(A; dims=2)
2×3 Matrix{Int64}:
 5  3  1
 6  4  2
```

The same call works on device arrays. Use `AK.reverse!(A; dims=2)` to modify
an array, or `AK.reverse!(B, A; dims=2)` to write into an existing destination.

`dims` accepts an integer or an iterable of distinct dimensions, such as `(1, 3)`.
The default `dims=:` preserves whole-array reversal; `dims=()` reverses nothing.
Invalid or duplicate dimensions throw `ArgumentError`. Destination and source must
not alias: their sizes must match for explicit dimensions, while `dims=:` continues
to require only matching lengths. Assignment converts to the destination element type.

Both operations use one parallel loop. In place, each mirrored pair is swapped once,
including pairs within the middle slice of an odd-sized dimension. No temporary device
array or host readback is needed. Existing CPU and GPU tuning keywords still apply.
The manual and README now list `reverse` and `reverse!`.

The new loop exposed a CUDA performance problem: the compiler left the `foreachindex`
closure as a separate device call, copying its captured state to local memory. A
call-site `@inline`, already used by the CPU path, removes that overhead. This keeps
the shared implementation competitive with a dedicated kernel.

Representative measurements from the preceding validation, Julia 1.12.7, RTX 5080,
4096×4096 `Float32` matrix; synchronised BenchmarkTools medians, 30 samples:

| Operation | Submitted PR | With inlining | CUDA.jl |
|---|---:|---:|---:|
| In place, `dims=1` | 0.390 ms | 0.127 ms | 0.127 ms |
| In place, `dims=2` | 0.390 ms | 0.077 ms | 0.075 ms |
| Out of place, `dims=1` | 0.995 ms | 0.166 ms | 0.169 ms |

For out-of-place reversal, AK uses a preallocated destination and CUDA.jl allocates
its result. A dedicated kernel measured 0.127, 0.076 and 0.166 ms respectively.
Apple M1 timings were essentially unchanged by inlining. These measurements precede
the final iterator-validation and destination-dispatch fixes; the device loop is unchanged.