### PR TITLE
Add `start`/`stop` keywords to `reverse` and `reverse!`

### DIFF
--- a/docs/src/api/reverse.md
+++ b/docs/src/api/reverse.md
@@ -1,5 +1,16 @@
 ### Reverse
 
+Use `dims` to reverse selected dimensions of an array, or `start` and `stop` to reverse
+part of a vector. Either bound may be omitted to use that end of the vector.
+
+```julia
+import AcceleratedKernels as AK
+
+v = [1, 2, 3, 4, 5]
+AK.reverse!(v; start=2, stop=4)  # v is now [1, 4, 3, 2, 5]
+w = AK.reverse(v; start=3)      # w is [1, 4, 5, 2, 3]; v is unchanged
+```
+
 ```@docs
 AcceleratedKernels.reverse!
 AcceleratedKernels.reverse

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -15,6 +15,21 @@ function check_reverse_dims(A, dims)
 end
 
 
+# Preserve the distinction between omitted bounds and an explicitly requested whole range.
+function check_reverse_range(v, dims, start::Union{Nothing,Integer}, stop::Union{Nothing,Integer})
+    isnothing(start) && isnothing(stop) && return nothing
+    dims isa Colon ||
+        throw(ArgumentError("`start`/`stop` cannot be combined with `dims`"))
+    v isa AbstractVector ||
+        throw(ArgumentError("`start`/`stop` are only supported for vectors"))
+    start = isnothing(start) ? firstindex(v) : Int(start)
+    stop = isnothing(stop) ? lastindex(v) : Int(stop)
+    # Base.reverse! skips bounds checks when no pair needs swapping.
+    stop > start && checkbounds(v, start:stop)
+    return start:stop
+end
+
+
 # Split along the last non-singleton reversed dimension. For odd extents, the middle
 # slice mirrors onto itself; the index ordering guard swaps each pair in it only once.
 function reverse_dims!(
@@ -71,6 +86,8 @@ end
         v::AbstractArray, backend::Backend=get_backend(v);
 
         dims=:,
+        start=nothing,
+        stop=nothing,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -82,12 +99,14 @@ end
 
 Reverse `v` in-place and return it. With `dims=:` (the default) the whole array is reversed; pass
 `dims=d` (an integer or an iterable of distinct integers in `1:ndims(v)`) to reverse only along
-those dimensions. `dims=()` leaves `v` unchanged. The CPU and GPU settings are the same as for
-[`foreachindex`](@ref).
+those dimensions. `dims=()` leaves `v` unchanged. For a vector, `start`/`stop` restrict the
+reversal to the sub-range `v[start:stop]`, as in `Base.reverse!(v, start, stop)`; they cannot be
+combined with `dims` other than `:`. Omitted bounds default to `firstindex(v)` and `lastindex(v)`.
+When `start >= stop`, nothing is reversed and bounds are not checked, as in Base's in-place
+method. Otherwise both bounds must lie within the vector. The CPU and GPU settings are the
+same as for [`foreachindex`](@ref).
 
 No temporary array is allocated.
-
-To reverse a contiguous sub-range of a vector, reverse a view: `AK.reverse!(@view v[lo:hi])`.
 
 # Examples
 ```julia
@@ -96,6 +115,7 @@ import AcceleratedKernels as AK
 
 v = CUDA.CuArray(1:100_000)
 AK.reverse!(v)
+AK.reverse!(v; start=10, stop=20)  # reverse only v[10:20]
 
 m = CUDA.CuArray(reshape(1:12, 3, 4))
 AK.reverse!(m; dims=2)          # reverse the columns
@@ -103,9 +123,15 @@ AK.reverse!(m; dims=2)          # reverse the columns
 """
 function reverse!(
     v::AbstractArray, backend::Backend=get_backend(v);
-    dims=:, kwargs...
+    dims=:, start=nothing, stop=nothing, kwargs...
 )
     dims = check_reverse_dims(v, dims)
+    range = check_reverse_range(v, dims, start, stop)
+    if !isnothing(range)
+        first(range) >= last(range) && return v
+        reverse!(view(v, range), backend; kwargs...)
+        return v
+    end
     if !(dims isa Colon)
         return reverse_dims!(v, dims, backend; kwargs...)
     end
@@ -136,6 +162,8 @@ end
         dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
 
         dims=:,
+        start=nothing,
+        stop=nothing,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -148,14 +176,32 @@ end
 Write the reverse of `src` into `dst` and return `dst`; `src` is left unchanged. `dst` and `src`
 must not alias. With `dims=:` (the default), the whole array is reversed and only the lengths
 must match. With an integer or iterable of distinct dimensions, the sizes must match. `dims=()`
-copies `src` unchanged. Elements are converted to the destination element type on assignment.
+copies `src` unchanged. For a vector `src`, `start`/`stop` reverse only `src[start:stop]` and copy
+the rest of `src` unchanged. Bounds default to `firstindex(src)` and `lastindex(src)` and cannot
+be combined with `dims` other than `:`. When `start >= stop`, this copies `src` without checking
+the bounds, following the in-place method; Base's allocating `reverse` may throw for these
+out-of-bounds ranges. Otherwise both bounds must lie within `src`.
+Elements are converted to the destination element type on assignment.
 The CPU and GPU settings are the same as for [`foreachindex`](@ref).
 """
 function reverse!(
     dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(src);
-    dims=:, kwargs...
+    dims=:, start=nothing, stop=nothing, kwargs...
 )
     dims = check_reverse_dims(src, dims)
+    range = check_reverse_range(src, dims, start, stop)
+    if !isnothing(range)
+        @argcheck length(dst) == length(src)
+        isempty(src) && return dst
+        # Fuse copying and reversal to avoid a second pass and synchronizing device copies.
+        lo, hi = first(range), last(range)
+        shift = firstindex(dst) - firstindex(src)
+        foreachindex(src, backend; kwargs...) do i
+            j = lo <= i <= hi ? lo + hi - i : i
+            @inbounds dst[j + shift] = src[i]
+        end
+        return dst
+    end
     if !(dims isa Colon)
         @argcheck size(dst) == size(src)
         length(src) == 0 && return dst
@@ -181,6 +227,8 @@ end
         v::AbstractArray, backend::Backend=get_backend(v);
 
         dims=:,
+        start=nothing,
+        stop=nothing,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -191,8 +239,10 @@ end
     )
 
 Return a reversed copy of `v`, leaving `v` unchanged. With `dims=:` (the default) the whole array is
-reversed; pass `dims=d` to reverse only along those dimensions, matching `Base.reverse`. The CPU and
-GPU settings are the same as for [`foreachindex`](@ref).
+reversed; pass `dims=d` to reverse only along those dimensions, or, for a vector, `start`/`stop` to
+reverse only the sub-range `v[start:stop]`. Bounds and their defaults follow [`reverse!`](@ref),
+including copying unchanged when `start >= stop` even if the bounds lie outside the vector.
+The CPU and GPU settings are the same as for [`foreachindex`](@ref).
 
 Prefer [`reverse!`](@ref) when you do not need to keep `v`; it avoids the allocation.
 """

--- a/test/generic/reverse.jl
+++ b/test/generic/reverse.jl
@@ -92,6 +92,110 @@
         end
     end
 
+    @testset "start/stop" begin
+        for T in test_types, n in (1, 2, 5, 256, 257, 1000)
+            h = rand(T, n)
+            # whole, prefix, suffix, interior, single element, empty (start > stop)
+            ranges = [(1, n), (1, n ÷ 2 + 1), (n ÷ 2 + 1, n), (max(1, n ÷ 4), min(n, 3n ÷ 4)),
+                      (min(n, 2), min(n, 2)), (min(n, 3), min(n, 2))]
+            for (lo, hi) in ranges
+                v = array_from_host(h)
+                @test AK.reverse!(v; start=lo, stop=hi, prefer_threads) === v
+                @test Array(v) == reverse!(copy(h), lo, hi)
+
+                src = array_from_host(h)
+                out = AK.reverse(src; start=lo, stop=hi, prefer_threads)
+                @test Array(out) == reverse(h, lo, hi)
+                @test Array(src) == h
+                @test out !== src
+
+                dst = array_from_host(zeros(T, n))
+                @test AK.reverse!(dst, src; start=lo, stop=hi, prefer_threads) === dst
+                @test Array(dst) == reverse(h, lo, hi)
+                @test Array(src) == h
+            end
+        end
+
+        # Either bound may be omitted; the other defaults to the end of the vector
+        h = rand(Float32, 1000)
+        v = array_from_host(h)
+        AK.reverse!(v; start=300, prefer_threads)
+        @test Array(v) == reverse!(copy(h), 300)
+        @test Array(AK.reverse(array_from_host(h); stop=300, prefer_threads)) == reverse(h, 1, 300)
+
+        # Integer types other than Int, and a range spanning several blocks
+        v = array_from_host(h)
+        AK.reverse!(v; start=Int32(3), stop=UInt16(999), prefer_threads, block_size=64)
+        @test Array(v) == reverse!(copy(h), 3, 999)
+
+        # Destination with a different element type
+        h_int = rand(Int32(1):Int32(1000), 1000)
+        dst = array_from_host(zeros(Float32, 1000))
+        AK.reverse!(dst, array_from_host(h_int); start=10, stop=20, prefer_threads)
+        @test Array(dst) == reverse(h_int, 10, 20)
+
+        # Bounds are relative to the view; elements outside it must remain unchanged.
+        h = Float32.(1:1000)
+        parent = array_from_host(h)
+        v = view(parent, 2:2:998)
+        expected = copy(h)
+        reverse!(view(expected, 2:2:998), 3, 490)
+        @test AK.reverse!(v; start=3, stop=490, prefer_threads) === v
+        @test Array(parent) == expected
+
+        src = view(array_from_host(h), 2:2:998)
+        dst_parent = array_from_host(zeros(Float32, 1000))
+        dst = view(dst_parent, 2:2:998)
+        @test AK.reverse!(dst, src; start=3, stop=490, prefer_threads) === dst
+        expected = zeros(Float32, 1000)
+        expected[2:2:998] = reverse(h[2:2:998], 3, 490)
+        @test Array(dst_parent) == expected
+        @test Array(src) == h[2:2:998]
+
+        # As for whole-array reversal, the destination only needs a matching length.
+        src = array_from_host(h)
+        dst = array_from_host(zeros(Float32, 20, 50))
+        @test AK.reverse!(dst, src; start=3, stop=990, prefer_threads) === dst
+        @test vec(Array(dst)) == reverse(h, 3, 990)
+        @test_throws ArgumentError AK.reverse!(similar(src, 999), src; start=3, prefer_threads)
+
+        # No swaps: Base.reverse! accepts even out-of-bounds empty and singleton ranges.
+        for n in (0, 1, 10), (lo, hi) in ((1, n), (0, 0), (n+1, n+1), (20, 19), (8, 3))
+            h = Float32.(1:n)
+            lo < hi && continue
+            src = array_from_host(h)
+            @test AK.reverse!(src; start=lo, stop=hi, prefer_threads) === src
+            @test Array(src) == reverse!(copy(h), lo, hi)
+            @test Array(AK.reverse(src; start=lo, stop=hi, prefer_threads)) == h
+            dst = similar(src)
+            @test AK.reverse!(dst, src; start=lo, stop=hi, prefer_threads) === dst
+            @test Array(dst) == h
+        end
+
+        # start/stop and dims are mutually exclusive
+        m = array_from_host(rand(Float32, 4, 5))
+        v = array_from_host(rand(Float32, 10))
+        @test_throws ArgumentError AK.reverse!(v; dims=1, start=2, prefer_threads)
+        @test_throws ArgumentError AK.reverse(v; dims=(1,), stop=3, prefer_threads)
+        @test_throws ArgumentError AK.reverse!(v; dims=1, start=1, stop=10, prefer_threads)
+        @test_throws MethodError AK.reverse!(v; start=1.0, prefer_threads)
+        @test_throws MethodError AK.reverse(v; stop=10.0, prefer_threads)
+
+        # start/stop are only defined for vectors
+        @test_throws ArgumentError AK.reverse!(m; start=2, prefer_threads)
+        @test_throws ArgumentError AK.reverse!(m; start=1, stop=length(m), prefer_threads)
+        @test_throws ArgumentError AK.reverse(m; stop=3, prefer_threads)
+        @test_throws ArgumentError AK.reverse!(similar(m), m; start=1, stop=2, prefer_threads)
+
+        # Out-of-bounds non-empty ranges throw; empty ranges are a no-op like in Base
+        @test_throws BoundsError AK.reverse!(v; start=0, stop=5, prefer_threads)
+        @test_throws BoundsError AK.reverse!(v; start=3, stop=11, prefer_threads)
+        @test_throws BoundsError AK.reverse(v; start=-1, prefer_threads)
+        h = Array(v)
+        @test Array(AK.reverse!(v; start=8, stop=3, prefer_threads)) == h
+        @test Array(AK.reverse(v; start=5, stop=5, prefer_threads)) == h
+    end
+
     # N-dimensional reversal along a subset of dimensions (Base.reverse parity)
     @testset "dims" begin
         # Single dimension, including a degenerate size-1 dim and a large 3-D array


### PR DESCRIPTION
Reverse part of a vector without changing the elements outside it. This extends the
whole-array and `dims` forms from #114 to support the subranges accepted by
`Base.reverse!(v, start, stop)`. Bounds are keywords because AK uses positional
arguments for the backend.

```julia
import AcceleratedKernels as AK

v = [1, 2, 3, 4, 5]                  # GPU vectors work the same way
AK.reverse!(v; start=2, stop=4)       # v == [1, 4, 3, 2, 5]
w = AK.reverse(v; start=3)           # w == [1, 4, 5, 2, 3]; v is unchanged

dst = similar(v)
AK.reverse!(dst, v; start=2, stop=4)  # write into a preallocated destination
```

Either integer bound may be omitted, defaulting to that end of the vector. Bounds
are supported only for vectors and cannot be combined with `dims` other than `:`.
For `start < stop`, both bounds must be in bounds. For `start >= stop`, the in-place
form does nothing and the out-of-place forms copy the source, without checking
bounds. This follows Base's **in-place** behavior; Base's allocating `reverse` can
throw for out-of-bounds empty or singleton ranges. A destination must have the same
length as the source and must not alias it.

In place, the implementation reverses a view using the existing loop. Out of place,
one pass copies elements outside the range and reverses those inside it. This avoids
processing the reversed range twice and avoids separate device copies that can
synchronize on Metal.

For context, these earlier review measurements use `Float32` vectors of length
2^26, Julia 1.12.7, and synchronized medians of 30 samples (milliseconds):

| Device | In place: whole vector | In place: middle half | Out of place: middle half |
|---|---:|---:|---:|
| NVIDIA RTX 5080 | 0.662 | 0.332 | 0.663 |
| Apple M1 | 9.52 | 4.77 | 9.20 |
| Intel Iris Xe | 28.6 | 14.1 | 33.0 |

The in-place keyword form measured similarly to reversing a view. Its work scales
with the range length; out of place, the whole vector still needs copying. CUDA.jl
measured 0.363 ms in place and 0.660 ms allocating for the middle half on the RTX
5080; AK's out-of-place measurement uses a preallocated destination. The Intel
middle-half copy/reversal was about 15% slower than its whole-vector reversal.